### PR TITLE
Check if `<h` line is numeric, fixes breakage on `<hr>` lines

### DIFF
--- a/src/mkdocstrings/plugin.py
+++ b/src/mkdocstrings/plugin.py
@@ -104,7 +104,7 @@ class MkdocstringsPlugin(BasePlugin):
         levels = [0]
         inserted = 0
         for i, line in enumerate(lines):
-            if line.startswith("<h"):
+            if line.startswith("<h") and line[2].isnumeric():
                 level = int(line[2])
                 if level > levels[-1]:
                     new_lines.insert(i + 1 + inserted, '<div class="autodoc">')


### PR DESCRIPTION
I have some `---` lines in my docstrings for better separation, and it broke the check for heading level. I realize this is brittle and subject to change, but in the meantime, figured I'd submit a fix.