### PR TITLE
Fix IndexError in Admonitions loop

### DIFF
--- a/src/mkdocstrings/documenter.py
+++ b/src/mkdocstrings/documenter.py
@@ -324,7 +324,7 @@ def parse_docstring(docstring: str, signature) -> str:
         elif lines[i].lower() in ADMONITIONS.keys():
             j = i + 1
             admonition = []
-            while j < len(lines) and lines[j].startswith("    ") or lines[j] == "":
+            while j < len(lines) and (lines[j].startswith("    ") or lines[j] == ""):
                 admonition.append(lines[j])
                 j += 1
             new_lines.append(f"!!! {ADMONITIONS[lines[i].lower()]}")


### PR DESCRIPTION
Due to some ungrouped logical statements, the first pair (`j < len(lines) and lines[j].startswith("    ")`) was getting skipped and the `or` was getting evaluated: `lines[j] == ""`, resulting in an `IndexError` when the admonition is at the end of the docstring:

```py

"""
Returns:
   return_value: Return value description

TODO:
   Write better docs.
"""
```
```py
File ".../lib/python3.6/site-packages/mkdocstrings/documenter.py", line 334, in parse_docstring
    while j < len(lines) and lines[j].startswith("    ") or lines[j] == "":
IndexError: list index out of range
```

This groups it so that checks on `lines[j]` only happen if `j` is in fact less than `len(lines)`, and thus, in range.