### PR TITLE
wip: Use extension

### DIFF
--- a/src/mkdocstrings/extension.py
+++ b/src/mkdocstrings/extension.py
@@ -1,0 +1,51 @@
+from markdown import Markdown
+from markdown.extensions import Extension
+from markdown.blockprocessors import BlockProcessor
+from markdown.util import etree
+import re
+
+
+class AutoDocProcessor(BlockProcessor):
+    CLASSNAME = "autodoc"
+    RE = re.compile(r"(?:^|\n)::: ?([:a-zA-Z0-9_.]*) *(?:\n|$)")
+
+    def __init__(self, parser, md, plugin):
+        super().__init__(parser=parser)
+        self.md = md
+        self.plugin = plugin
+
+    def test(self, parent: etree.Element, block: etree.Element) -> bool:
+        sibling = self.lastChild(parent)
+        bool1 = self.RE.search(block)
+        bool2 = (
+                block.startswith(" " * self.tab_length)
+                and sibling is not None
+                and sibling.get("class", "").find(self.CLASSNAME) != -1
+            )
+        return bool(bool1 or bool2)
+
+    def run(self, parent: etree.Element, blocks: etree.Element) -> None:
+        block = blocks.pop(0)
+        m = self.RE.search(block)
+
+        if m:
+            block = block[m.end() :]  # removes the first line
+
+        block, theRest = self.detab(block)
+
+        if theRest:
+            # This block contained unindented line(s) after the first indented
+            # line. Insert these lines as the first block of the master blocks
+            # list for future processing.
+            blocks.insert(0, theRest)
+
+
+class MkdocstringsExtension(Extension):
+    def __init__(self, plugin, **kwargs):
+        super().__init__(**kwargs)
+        self.plugin = plugin
+
+    def extendMarkdown(self, md: Markdown) -> None:
+        md.registerExtension(self)
+        processor = AutoDocProcessor(md.parser, md, self.plugin)
+        md.parser.blockprocessors.register(processor, "mkdocstrings", 110)

--- a/src/mkdocstrings/plugin.py
+++ b/src/mkdocstrings/plugin.py
@@ -4,6 +4,7 @@ from mkdocs.config.config_options import Type as MkType
 from mkdocs.plugins import BasePlugin
 
 from .documenter import Documenter
+from .extension import MkdocstringsExtension
 
 # TODO: show source file in source code blocks titles
 
@@ -55,6 +56,8 @@ class MkdocstringsPlugin(BasePlugin):
     def on_config(self, config, **kwargs):
         """Initializes a [Documenter][mkdocstrings.documenter.Documenter]."""
         self.documenter = Documenter(self.config["global_filters"])
+        extension = MkdocstringsExtension(self)
+        config["markdown_extensions"].append(extension)
         return config
 
     def on_nav(self, nav, **kwargs):
@@ -79,7 +82,7 @@ class MkdocstringsPlugin(BasePlugin):
                             self.pages_with_docstrings.append(page.abs_url)
         return nav
 
-    def on_page_markdown(self, markdown, page, **kwargs):
+    def _on_page_markdown(self, markdown, page, **kwargs):
         if page.abs_url not in self.pages_with_docstrings:
             return markdown
         lines = markdown.split("\n")
@@ -96,7 +99,7 @@ class MkdocstringsPlugin(BasePlugin):
         modified_lines.extend(self.references)
         return "\n".join(modified_lines)
 
-    def on_page_content(self, html, page, **kwargs):
+    def _on_page_content(self, html, page, **kwargs):
         if page.abs_url not in self.pages_with_docstrings:
             return html
         lines = html.split("\n")


### PR DESCRIPTION
Just a reminder of how we will do this. Not to be merged.

The roadmap is:
1. refactor documenter.py to really separate the build process from the rendering process
2. move the rendering code to an extension (from "markdown to markdown+features" to "markdown to html")