### PR TITLE
WIP: refactor: Use Object subclasses

### DIFF
--- a/scripts/gen-credits-data.py
+++ b/scripts/gen-credits-data.py
@@ -9,18 +9,8 @@ import toml
 from pip._internal.commands.show import search_packages_info
 
 
-def add_vlz_url(p):
-    try:
-        with open(Path(__file__).parent / "templates" / "vlz" / (p["name"] + ".txt")) as stream:
-            p["vlz-url"] = stream.read().rstrip("\n")
-    except FileNotFoundError:
-        pass
-    return p
-
-
 def clean_info(p):
-    p = add_vlz_url(p)
-    return {k: v for k, v in p.items() if k in ("name", "home-page", "vlz-url")}
+    return {k: v for k, v in p.items() if k in ("name", "home-page")}
 
 
 metadata = toml.load(Path(__file__).parent.parent / "pyproject.toml")["tool"]["poetry"]
@@ -38,9 +28,10 @@ package_info = {p["name"]: clean_info(p) for p in search_packages_info(direct_de
 for dependency in direct_dependencies + indirect_dependencies:
     if dependency not in [_.lower() for _ in package_info.keys()]:
         info = requests.get(f"https://pypi.python.org/pypi/{dependency}/json").json()["info"]
-        package_info[info["name"]] = add_vlz_url(
-            {"name": info["name"], "home-page": info["home_page"] or info["project_url"] or info["package_url"]}
-        )
+        package_info[info["name"]] = {
+            "name": info["name"],
+            "home-page": info["home_page"] or info["project_url"] or info["package_url"],
+        }
 
 lower_package_info = {}
 for package_name, package in package_info.items():

--- a/scripts/templates/CREDITS.md
+++ b/scripts/templates/CREDITS.md
@@ -7,25 +7,22 @@ IMPORTANT:
 # Credits
 These projects were used to build `mkdocstrings`. **Thank you!**
 
-[![`python`](https://www.vectorlogo.zone/logos/python/python-ar21.svg)](https://www.python.org/) |
+[`python`](https://www.python.org/) |
 [`poetry`](https://poetry.eustace.io/) |
 [`cookie-poetry`](https://github.com/pawamoy/cookie-poetry)
 
 ### Direct dependencies
 {%- for dep in direct_dependencies -%}
 {%- with package = package_info.get(dep, {}) %}
-[{% if package.get("vlz-url") %}![{% endif %}`{{ package.get("name", dep) }}`]{% if package.get("vlz-url") %}({{ package["vlz-url"] }})]{% endif %}({{ package.get("home-page", "") }}){% if not loop.last %} |{% endif %}
+[`{{ package.get("name", dep) }}`]({{ package.get("home-page", "") }}){% if not loop.last %} |{% endif %}
 {%- endwith -%}
 {%- endfor %}
 
 ### Indirect dependencies
 {%- for dep in indirect_dependencies -%}
 {%- with package = package_info.get(dep, {}) %}
-[{% if package.get("vlz-url") %}![{% endif %}`{{ package.get("name", dep) }}`]{% if package.get("vlz-url") %}({{ package["vlz-url"] }})]{% endif %}({{ package.get("home-page", "") }}){% if not loop.last %} |{% endif %}
+[`{{ package.get("name", dep) }}`]({{ package.get("home-page", "") }}){% if not loop.last %} |{% endif %}
 {%- endwith -%}
 {%- endfor %}
 
 **[More credits from the author](http://pawamoy.github.io/credits/)**
-
-*See one of your project without the logo? Make sure it's available on [VectorLogoZone](https://www.vectorlogo.zone/)
-([GitHub repo](https://github.com/VectorLogoZone/vectorlogozone)) and open an issue or send a pull/merge request!*

--- a/scripts/templates/vlz/Jinja2.txt
+++ b/scripts/templates/vlz/Jinja2.txt
@@ -1,1 +1,0 @@
-https://www.vectorlogo.zone/logos/pocoo_jinja/pocoo_jinja-ar21.svg

--- a/scripts/templates/vlz/commonmark.txt
+++ b/scripts/templates/vlz/commonmark.txt
@@ -1,1 +1,0 @@
-https://www.vectorlogo.zone/logos/commonmark/commonmark-ar21.svg

--- a/src/mkdocstrings/documenter.py
+++ b/src/mkdocstrings/documenter.py
@@ -44,13 +44,439 @@ NAME_SPECIAL = ("special", lambda n: bool(RE_SPECIAL.match(n)))
 NAME_CLASS_PRIVATE = ("class-private", lambda n: bool(RE_CLASS_PRIVATE.match(n)))
 NAME_PRIVATE = ("private", lambda n: bool(RE_PRIVATE.match(n)))
 
-NAME_PROPERTIES = {
-    CATEGORY_ATTRIBUTE: [NAME_SPECIAL, NAME_CLASS_PRIVATE, NAME_PRIVATE],
-    CATEGORY_METHOD: [NAME_SPECIAL, NAME_PRIVATE],
-    CATEGORY_FUNCTION: [NAME_PRIVATE],
-    CATEGORY_CLASS: [NAME_PRIVATE],
-    CATEGORY_MODULE: [NAME_SPECIAL, NAME_PRIVATE],
+ADMONITIONS = {
+    "note:": "note",
+    "see also:": "seealso",
+    "abstract:": "abstract",
+    "summary:": "summary",
+    "tldr:": "tldr",
+    "info:": "info",
+    "information:": "info",
+    "todo:": "todo",
+    "tip:": "tip",
+    "hint:": "hint",
+    "important:": "important",
+    "success:": "success",
+    "check:": "check",
+    "done:": "done",
+    "question:": "question",
+    "help:": "help",
+    "faq:": "faq",
+    "warning:": "warning",
+    "caution:": "caution",
+    "attention:": "attention",
+    "failure:": "failure",
+    "fail:": "fail",
+    "missing:": "missing",
+    "danger:": "danger",
+    "error:": "error",
+    "bug:": "bug",
+    "example:": "example",
+    "snippet:": "snippet",
+    "quote:": "quote",
+    "cite:": "cite",
 }
+
+
+class Object:
+    """
+    Class to store information about a Python object.
+
+    - the object category (ex: module, function, class, method or attribute)
+    - the object path (ex: `package.submodule.class.inner_class.method`)
+    - the object name (ex: `__init__`)
+    - the object docstring
+    - the object properties, depending on its category (ex: special, classmethod, etc.)
+    - the object signature (soon)
+
+    Each instance additionally stores references to its children, grouped by category (see Attributes).
+    """
+
+    NAME_PROPERTIES = []
+
+    def __init__(
+        self,
+        name: str,
+        path: str,
+        file_path: str,
+        docstring: str,
+        properties: Optional[List[str]] = None,
+        signature: Optional[inspect.Signature] = None,
+        source: Optional[str] = None,
+        file: Optional[str] = None,
+    ) -> None:
+        self.name = name
+        self.signature = signature or ""
+        self.path = path
+        self.file_path = file_path
+        self.docstring = docstring or ""
+        self.properties = properties or []
+        self.parent = None
+        self.source = source or ""
+        self.file = file or ""
+
+        self._path_map = {}
+
+        self.attributes: List[Attribute] = []
+        """List of all the object's attributes."""
+        self.methods: List[Method] = []
+        """List of all the object's methods."""
+        self.functions: List[Function] = []
+        """List of all the object's functions."""
+        self.modules: List[Module] = []
+        """List of all the object's submodules."""
+        self.classes: List[Class] = []
+        """List of all the object's classes."""
+        self.children: List[Union[Attribute, Method, Function, Module, Class]] = []
+        """List of all the object's children."""
+
+    def __str__(self):
+        return self.path
+
+    @property
+    def is_module(self):
+        return False
+
+    @property
+    def is_class(self):
+        return False
+
+    @property
+    def is_function(self):
+        return False
+
+    @property
+    def is_method(self):
+        return False
+
+    @property
+    def is_attribute(self):
+        return False
+
+    @property
+    def name_to_check(self):
+        return self.name
+
+    @property
+    def name_properties(self) -> List[str]:
+        properties = []
+        for prop, predicate in self.NAME_PROPERTIES:
+            if predicate(self.name_to_check):
+                properties.append(prop)
+        return properties
+
+    @property
+    def parent_path(self) -> str:
+        """The parent's path, computed from the current path."""
+        return self.path.rsplit(".", 1)[0]
+
+    def add_child(self, obj: Union["Attribute", "Method", "Function", "Module", "Class"]) -> None:
+        """Add an object as a child of this object."""
+        if obj.parent_path != self.path:
+            return
+
+        self.children.append(obj)
+        if obj.is_module:
+            self.modules.append(obj)
+        elif obj.is_class:
+            self.classes.append(obj)
+        elif obj.is_function:
+            self.functions.append(obj)
+        elif obj.is_method:
+            self.methods.append(obj)
+        elif obj.is_attribute:
+            self.attributes.append(obj)
+        obj.parent = self
+
+        self._path_map[obj.path] = obj
+
+    def add_children(self, children: List[Union["Attribute", "Method", "Function", "Module", "Class"]]) -> None:
+        """Add a list of objects as children of this object."""
+        for child in children:
+            self.add_child(child)
+
+    def dispatch_attributes(self, attributes: List["Attribute"]) -> None:
+        for attribute in attributes:
+            try:
+                attach_to = self._path_map[attribute.parent_path]
+            except KeyError:
+                pass
+            else:
+                attach_to.attributes.append(attribute)
+                attach_to.children.append(attribute)
+                attribute.parent = attach_to
+
+    def render_references(self, base_url: str):
+        lines = [f"[{self.path}]: {base_url}#{self.path}"]
+        for child in self.children:
+            lines.append(child.render_references(base_url))
+        return "\n".join(lines)
+
+    def render(self, heading: int = 1, **config: Dict[str, Any]) -> str:
+        """
+        Render this object as Markdown.
+
+        This is dirty and will be refactored as a Markdown extension soon.
+
+        Parameters:
+            heading: The initial level of heading to use.
+            config: The rendering configuration dictionary.
+
+        Returns:
+            The rendered Markdown.
+        """
+        lines = []
+
+        show_top_object_heading = config.pop("show_top_object_heading", True)
+        show_top_object_full_path = config.pop("show_top_object_full_path", False)
+        if show_top_object_heading:
+            if self.docstring or not config["hide_no_doc"] or not self.parent:
+                signature = ""
+                toc_signature = ""
+                if self.is_function or self.is_method:
+                    if self.signature:
+                        signature = f"({render_signature(self.signature)})"
+                    toc_signature = "()"
+                elif self.is_attribute:
+                    if "property" in self.properties:
+                        signature = f": {get_return_type(self.signature)}"
+                    else:
+                        signature = f": {self.signature}"
+                object_heading = f"`:::python {self.path if show_top_object_full_path else self.name}{signature}`"
+                object_permalink = self.path.replace("__", r"\_\_")
+                object_toc = self.name.replace("__", r"\_\_") + toc_signature
+
+                properties = ", ".join(self.properties)
+                if properties:
+                    object_heading += f"*({properties})*"
+
+                lines.append(
+                    f"{'#' * heading} {object_heading} {{: #{object_permalink} data-toc-label='{object_toc}' }}"
+                )
+
+                if config["add_source_details"] and self.source:
+                    lines.append("")
+                    lines.append(f'??? note "Show source code"')
+                    lines.append(f'    ```python linenums="{self.source[1]}"')
+                    lines.append(textwrap.indent("".join(self.source[0]), "    "))
+                    lines.append("    ```")
+                    lines.append("")
+
+        if self.docstring:
+            lines.append(parse_docstring(self.docstring, self.signature))
+            lines.append("")
+
+        if config["group_by_categories"]:
+            lines.append(self.render_categories(heading + 1, **config,))
+        else:
+            for child in sorted(self.children, key=lambda o: o.name.lower()):
+                lines.append(child.render(heading + 1, **config,))
+                lines.append("")
+
+        return "\n".join(lines)
+
+    def render_categories(self, heading: int, **config):
+        extra_level = 1 if config["show_groups_headings"] else 0
+        lines = []
+
+        if self.attributes:
+            if config["show_groups_headings"]:
+                lines.append(f"{'#' * heading} Attributes")
+                lines.append("")
+            for attribute in sorted(self.attributes, key=lambda o: o.name.lower()):
+                lines.append(attribute.render(heading + extra_level, **config))
+                lines.append("")
+        if self.classes:
+            if config["show_groups_headings"]:
+                lines.append(f"{'#' * heading} Classes")
+                lines.append("")
+            for class_ in sorted(self.classes, key=lambda o: o.name.lower()):
+                lines.append(class_.render(heading + extra_level, **config))
+                lines.append("")
+        if self.methods:
+            if config["show_groups_headings"]:
+                lines.append(f"{'#' * heading} Methods")
+                lines.append("")
+            for method in sorted(self.methods, key=lambda o: o.name.lower()):
+                lines.append(method.render(heading + extra_level, **config))
+                lines.append("")
+        if self.functions:
+            if config["show_groups_headings"]:
+                lines.append(f"{'#' * heading} Functions")
+                lines.append("")
+            for function in sorted(self.functions, key=lambda o: o.name.lower()):
+                lines.append(function.render(heading + extra_level, **config))
+                lines.append("")
+        return "\n".join(lines)
+
+
+class Module(Object):
+    NAME_PROPERTIES = [NAME_SPECIAL, NAME_PRIVATE]
+
+    @property
+    def is_module(self):
+        return True
+
+    @property
+    def file_name(self):
+        return os.path.splitext(os.path.basename(self.file_path))[0]
+
+    @property
+    def name_to_check(self):
+        return self.file_name
+
+
+class Class(Object):
+    NAME_PROPERTIES = [NAME_PRIVATE]
+
+    @property
+    def is_class(self):
+        return True
+
+
+class Function(Object):
+    NAME_PROPERTIES = [NAME_PRIVATE]
+
+    @property
+    def is_function(self):
+        return True
+
+
+class Method(Object):
+    NAME_PROPERTIES = [NAME_SPECIAL, NAME_PRIVATE]
+
+    @property
+    def is_method(self):
+        return True
+
+
+class Attribute(Object):
+    NAME_PROPERTIES = [NAME_SPECIAL, NAME_CLASS_PRIVATE, NAME_PRIVATE]
+
+    @property
+    def is_attribute(self):
+        return True
+
+
+class Documenter:
+    """Class that contains the object documentation loading mechanisms."""
+
+    def __init__(self, global_filters):
+        self.global_filters = [(f, re.compile(f.lstrip("!"))) for f in global_filters]
+
+    def get_object_documentation(self, import_string: str) -> Union[Attribute, Method, Function, Module, Class]:
+        """
+        Documenting to see return type.
+
+        Return:
+            The object with all its children populated.
+        """
+        module, obj = import_object(import_string)
+        attributes = get_attributes(module)
+        if inspect.ismodule(obj):
+            root_object = self.get_module_documentation(obj)
+        elif inspect.isclass(obj):
+            root_object = self.get_class_documentation(obj, module)
+        elif inspect.isfunction(obj):
+            root_object = self.get_function_documentation(obj, module)
+        else:
+            raise ValueError(f"{obj}:{type(obj)} not yet supported")
+        root_object.dispatch_attributes([a for a in attributes if not self.filter_name_out(a.name)])
+        return root_object
+
+    def get_module_documentation(self, module: ModuleType) -> Module:
+        path = module.__name__
+        name = path.split(".")[-1]
+        root_object = Module(name=name, path=path, file_path=module.__file__, docstring=inspect.getdoc(module),)
+        for member_name, member in filter(lambda m: not self.filter_name_out(m[0]), inspect.getmembers(module)):
+            if inspect.isclass(member) and inspect.getmodule(member) == module:
+                root_object.add_child(self.get_class_documentation(member, module))
+            elif inspect.isfunction(member) and inspect.getmodule(member) == module:
+                root_object.add_child(self.get_function_documentation(member, module))
+        return root_object
+
+    def get_class_documentation(self, class_: Type[Any], module: Optional[ModuleType] = None) -> Class:
+        if module is None:
+            module = inspect.getmodule(class_)
+        class_name = class_.__name__
+        path = f"{module.__name__}.{class_name}"
+        file_path = module.__file__
+        root_object = Class(
+            name=class_name,
+            path=path,
+            file_path=file_path,
+            docstring=textwrap.dedent(class_.__doc__ or ""),
+            signature=inspect.signature(class_),
+        )
+
+        for member_name, member in sorted(filter(lambda m: not self.filter_name_out(m[0]), class_.__dict__.items())):
+            if inspect.isclass(member):
+                root_object.add_child(self.get_class_documentation(member))
+                continue
+
+            member_class = properties = signature = None
+            member_path = f"{path}.{member_name}"
+            actual_member = getattr(class_, member_name)
+            docstring = inspect.getdoc(actual_member)
+            try:
+                source = inspect.getsourcelines(actual_member)
+            except TypeError:
+                source = ""
+
+            if isinstance(member, classmethod):
+                properties = ["classmethod"]
+                member_class = Method
+                signature = inspect.signature(actual_member)
+            elif isinstance(member, staticmethod):
+                properties = ["staticmethod"]
+                member_class = Method
+                signature = inspect.signature(actual_member)
+            elif isinstance(member, type(lambda: 0)):  # regular method
+                member_class = Method
+                signature = inspect.signature(actual_member)
+            elif isinstance(member, property):
+                properties = ["property", "readonly" if member.fset is None else "writable"]
+                signature = inspect.signature(actual_member.fget)
+                member_class = Attribute
+
+            if member_class:
+                root_object.add_child(
+                    member_class(
+                        name=member_name,
+                        path=member_path,
+                        file_path=file_path,
+                        docstring=docstring,
+                        properties=properties,
+                        source=source,
+                        signature=signature,
+                    )
+                )
+        return root_object
+
+    def get_function_documentation(self, function: Callable, module: Optional[ModuleType] = None) -> Function:
+        if module is None:
+            module = inspect.getmodule(function)
+        function_name = function.__name__
+        path = f"{module.__name__}.{function_name}"
+        return Function(
+            name=function_name,
+            path=path,
+            file_path=module.__file__,
+            docstring=inspect.getdoc(function),
+            source=inspect.getsourcelines(function),
+            signature=inspect.signature(function),
+        )
+
+    @lru_cache(maxsize=None)
+    def filter_name_out(self, name: str) -> bool:
+        keep = True
+        for f, regex in self.global_filters:
+            is_matching = bool(regex.match(name))
+            if is_matching:
+                if str(f).startswith("!"):
+                    is_matching = not is_matching
+                keep = is_matching
+        return not keep
 
 
 def node_is_docstring(node: ast.AST) -> bool:
@@ -65,66 +491,92 @@ def node_is_assignment(node: ast.AST) -> bool:
     return isinstance(node, ast.Assign)
 
 
-def node_to_names(node: ast.Assign) -> List[str]:
+def node_is_annotated_assignment(node: ast.AST) -> bool:
+    return isinstance(node, ast.AnnAssign)
+
+
+def node_to_names(node: ast.Assign) -> dict:
     names = []
     for target in node.targets:
         if isinstance(target, ast.Attribute):
             names.append(target.attr)
         elif isinstance(target, ast.Name):
             names.append(target.id)
-    return names
+    return {"names": names, "lineno": node.lineno, "signature": None}
 
 
-def get_name_properties(name: str, category: str) -> List[str]:
-    properties = []
-    for prop in NAME_PROPERTIES[category]:
-        if prop[1](name):
-            properties.append(prop[0])
-    return properties
+def node_to_annotated_names(node: ast.AnnAssign) -> dict:
+    name = node.target.attr
+    lineno = node.lineno
+    return {"names": [name], "lineno": lineno, "signature": node_to_annotation(node)}
 
 
-def get_attribute_names_and_docstring(node1, node2):
-    if node_is_docstring(node2) and node_is_assignment(node1):
-        return node_to_names(node1), node_to_docstring(node2)
-    raise ValueError
+def node_to_annotation(node) -> str:
+    if isinstance(node, ast.AnnAssign):
+        annotation = node.annotation.value.id
+        if hasattr(node.annotation, "slice"):
+            annotation += f"[{node_to_annotation(node.annotation.slice.value)}]"
+        return annotation
+    elif isinstance(node, ast.Subscript):
+        return f"{node.value.id}[{node_to_annotation(node.slice.value)}]"
+    elif isinstance(node, ast.Tuple):
+        return ", ".join(node_to_annotation(n) for n in node.elts)
+    elif isinstance(node, ast.Name):
+        return node.id
+
+
+def get_attribute_info(node1, node2):
+    if node_is_docstring(node2):
+        info = {"docstring": node_to_docstring(node2)}
+        if node_is_assignment(node1):
+            info.update(node_to_names(node1))
+            return info
+        elif node_is_annotated_assignment(node1):
+            info.update(node_to_annotated_names(node1))
+            return info
+    raise ValueError(f"nodes must be assignment and docstring, not '{node1}' and '{node2}'")
 
 
 @lru_cache(maxsize=None)
-def get_attributes(module: ModuleType) -> List["Object"]:
-    with open(module.__file__) as stream:
+def get_attributes(module: ModuleType) -> List[Attribute]:
+    file_path = module.__file__
+    with open(file_path) as stream:
         code = stream.read()
     initial_ast_body = ast.parse(code).body
-    return _get_attributes(initial_ast_body, name_prefix=module.__name__)
+    return _get_attributes(initial_ast_body, name_prefix=module.__name__, file_path=file_path)
 
 
-def _get_attributes(ast_body: list, name_prefix: str, properties: Optional[List[str]] = None) -> List["Object"]:
+def _get_attributes(
+    ast_body: list, name_prefix: str, file_path: str, properties: Optional[List[str]] = None
+) -> List[Attribute]:
     if not properties:
         properties = []
     documented_attributes = []
     previous_node = None
     for node in ast_body:
         try:
-            names, docstring = get_attribute_names_and_docstring(previous_node, node)
+            attr_info = get_attribute_info(previous_node, node)
         except ValueError:
             if isinstance(node, RECURSIVE_NODES):
-                documented_attributes.extend(_get_attributes(node.body, name_prefix, properties))
+                documented_attributes.extend(_get_attributes(node.body, name_prefix, file_path, properties))
                 if isinstance(node, ast.Try):
-                    documented_attributes.extend(_get_attributes(node.finalbody, name_prefix, properties))
+                    documented_attributes.extend(_get_attributes(node.finalbody, name_prefix, file_path, properties))
             elif isinstance(node, ast.FunctionDef) and node.name == "__init__":
-                documented_attributes.extend(_get_attributes(node.body, name_prefix))
+                documented_attributes.extend(_get_attributes(node.body, name_prefix, file_path))
             elif isinstance(node, ast.ClassDef):
                 documented_attributes.extend(
-                    _get_attributes(node.body, f"{name_prefix}.{node.name}", properties=["class"])
+                    _get_attributes(node.body, f"{name_prefix}.{node.name}", file_path, properties=["class"])
                 )
         else:
-            for name in names:
+            for name in attr_info["names"]:
                 documented_attributes.append(
-                    Object(
-                        category=CATEGORY_ATTRIBUTE,
-                        path=f"{name_prefix}.{name}",
+                    Attribute(
                         name=name,
-                        docstring=docstring,
-                        properties=properties + get_name_properties(name, CATEGORY_ATTRIBUTE),
+                        path=f"{name_prefix}.{name}",
+                        file_path=file_path,
+                        docstring=attr_info["docstring"],
+                        properties=properties,
+                        signature=attr_info["signature"],
                     )
                 )
         previous_node = node
@@ -168,40 +620,6 @@ def import_object(path: str) -> Tuple[ModuleType, Any]:
         current_object = getattr(current_object, obj)
     module = inspect.getmodule(current_object)
     return module, current_object
-
-
-ADMONITIONS = {
-    "note:": "note",
-    "see also:": "seealso",
-    "abstract:": "abstract",
-    "summary:": "summary",
-    "tldr:": "tldr",
-    "info:": "info",
-    "information:": "info",
-    "todo:": "todo",
-    "tip:": "tip",
-    "hint:": "hint",
-    "important:": "important",
-    "success:": "success",
-    "check:": "check",
-    "done:": "done",
-    "question:": "question",
-    "help:": "help",
-    "faq:": "faq",
-    "warning:": "warning",
-    "caution:": "caution",
-    "attention:": "attention",
-    "failure:": "failure",
-    "fail:": "fail",
-    "missing:": "missing",
-    "danger:": "danger",
-    "error:": "error",
-    "bug:": "bug",
-    "example:": "example",
-    "snippet:": "snippet",
-    "quote:": "quote",
-    "cite:": "cite",
-}
 
 
 def render_signature(signature):
@@ -260,7 +678,7 @@ def get_return_type(signature):
     return ret_type
 
 
-def parse_docstring(docstring: str, signature) -> str:
+def parse_docstring(docstring: str, signature: inspect.Signature) -> str:
     """
     Parse a docstring!
 
@@ -268,7 +686,8 @@ def parse_docstring(docstring: str, signature) -> str:
         to try notes.
 
     Args:
-        docstring: this is the docstring to parse.
+        docstring: This is the docstring to parse.
+        signature: The signature returned by inspect.
 
     Raises:
         OSError: no it doesn't lol.
@@ -349,344 +768,3 @@ def parse_docstring(docstring: str, signature) -> str:
         i += 1
 
     return "\n".join(new_lines)
-
-
-class Object:
-    """
-    Class to store information about a Python object.
-
-    - the object category (ex: module, function, class, method or attribute)
-    - the object path (ex: `package.submodule.class.inner_class.method`)
-    - the object name (ex: `__init__`)
-    - the object docstring
-    - the object properties, depending on its category (ex: special, classmethod, etc.)
-    - the object signature (soon)
-
-    Each instance additionally stores references to its children, grouped by category (see Attributes).
-    """
-
-    def __init__(
-        self,
-        category: str,
-        name: str,
-        path: str,
-        docstring: str,
-        properties: List[str],
-        signature: Optional[str] = None,
-        source: Optional[str] = None,
-        file: Optional[str] = None,
-    ) -> None:
-        self.category = category
-        self.name = name
-        self.signature = signature or ""
-        self.path = path
-        self.docstring = docstring or ""
-        self.properties = properties
-        self.parent = None
-        self.source = source or ""
-        self.file = file or ""
-
-        self._path_map = {}
-
-        self.attributes = []
-        """List of all the object's attributes."""
-        self.methods = []
-        """List of all the object's methods."""
-        self.functions = []
-        """List of all the object's functions."""
-        self.modules = []
-        """List of all the object's submodules."""
-        self.classes = []
-        """List of all the object's classes."""
-        self.children = []
-        """List of all the object's children."""
-
-    def __str__(self):
-        return self.path
-
-    @property
-    def parent_path(self) -> str:
-        """The parent's path, computed from the current path."""
-        return self.path.rsplit(".", 1)[0]
-
-    def add_child(self, obj: "Object") -> None:
-        """Add an object as a child of this object."""
-        if obj.parent_path != self.path:
-            return
-
-        self.children.append(obj)
-        {
-            CATEGORY_ATTRIBUTE: self.attributes,
-            CATEGORY_METHOD: self.methods,
-            CATEGORY_FUNCTION: self.functions,
-            CATEGORY_MODULE: self.modules,
-            CATEGORY_CLASS: self.classes,
-        }.get(obj.category).append(obj)
-        obj.parent = self
-
-        self._path_map[obj.path] = obj
-
-    def add_children(self, children: List["Object"]) -> None:
-        """Add a list of objects as children of this object."""
-        for child in children:
-            self.add_child(child)
-
-    def dispatch_attributes(self, attributes: List["Object"]) -> None:
-        for attribute in attributes:
-            try:
-                attach_to = self._path_map[attribute.parent_path]
-            except KeyError:
-                pass
-            else:
-                attach_to.attributes.append(attribute)
-                attach_to.children.append(attribute)
-                attribute.parent = attach_to
-
-    def render_references(self, base_url: str):
-        lines = [f"[{self.path}]: {base_url}#{self.path}"]
-        for child in self.children:
-            lines.append(child.render_references(base_url))
-        return "\n".join(lines)
-
-    def render(self, heading: int = 1, **config: Dict[str, Any]) -> str:
-        """
-        Render this object as Markdown.
-
-        This is dirty and will be refactored as a Markdown extension soon.
-
-        Parameters:
-            heading: The initial level of heading to use.
-            config: The rendering configuration dictionary.
-
-        Returns:
-            The rendered Markdown.
-        """
-        lines = []
-
-        show_top_object_heading = config.pop("show_top_object_heading", True)
-        show_top_object_full_path = config.pop("show_top_object_full_path", False)
-        if show_top_object_heading:
-            if self.docstring or not config["hide_no_doc"] or not self.parent:
-                signature = ""
-                toc_signature = ""
-                if self.category in (CATEGORY_FUNCTION, CATEGORY_METHOD):
-                    if self.signature:
-                        signature = f"({render_signature(self.signature)})"
-                    toc_signature = "()"
-                object_heading = f"`:::python {self.path if show_top_object_full_path else self.name}{signature}`"
-                object_permalink = self.path.replace("__", r"\_\_")
-                object_toc = self.name.replace("__", r"\_\_") + toc_signature
-
-                properties = ", ".join(self.properties)
-                if properties:
-                    object_heading += f"*({properties})*"
-
-                lines.append(
-                    f"{'#' * heading} {object_heading} {{: #{object_permalink} data-toc-label='{object_toc}' }}"
-                )
-
-                if config["add_source_details"] and self.source:
-                    lines.append("")
-                    lines.append(f'??? note "Show source code"')
-                    lines.append(f'    ```python linenums="{self.source[1]}"')
-                    lines.append(textwrap.indent("".join(self.source[0]), "    "))
-                    lines.append("    ```")
-                    lines.append("")
-
-        if self.docstring:
-            lines.append(parse_docstring(self.docstring, self.signature))
-            lines.append("")
-
-        if config["group_by_categories"]:
-            lines.append(self.render_categories(heading + 1, **config,))
-        else:
-            for child in sorted(self.children, key=lambda o: o.name.lower()):
-                lines.append(child.render(heading + 1, **config,))
-                lines.append("")
-
-        return "\n".join(lines)
-
-    def render_categories(self, heading: int, **config):
-        extra_level = 1 if config["show_groups_headings"] else 0
-        lines = []
-
-        if self.attributes:
-            if config["show_groups_headings"]:
-                lines.append(f"{'#' * heading} Attributes")
-                lines.append("")
-            for attribute in sorted(self.attributes, key=lambda o: o.name.lower()):
-                lines.append(attribute.render(heading + extra_level, **config))
-                lines.append("")
-        if self.classes:
-            if config["show_groups_headings"]:
-                lines.append(f"{'#' * heading} Classes")
-                lines.append("")
-            for class_ in sorted(self.classes, key=lambda o: o.name.lower()):
-                lines.append(class_.render(heading + extra_level, **config))
-                lines.append("")
-        if self.methods:
-            if config["show_groups_headings"]:
-                lines.append(f"{'#' * heading} Methods")
-                lines.append("")
-            for method in sorted(self.methods, key=lambda o: o.name.lower()):
-                lines.append(method.render(heading + extra_level, **config))
-                lines.append("")
-        if self.functions:
-            if config["show_groups_headings"]:
-                lines.append(f"{'#' * heading} Functions")
-                lines.append("")
-            for function in sorted(self.functions, key=lambda o: o.name.lower()):
-                lines.append(function.render(heading + extra_level, **config))
-                lines.append("")
-        return "\n".join(lines)
-
-
-class Documenter:
-    """Class that contains the object documentation loading mechanisms."""
-
-    def __init__(self, global_filters):
-        self.global_filters = [(f, re.compile(f.lstrip("!"))) for f in global_filters]
-
-    def get_object_documentation(self, import_string: str) -> Object:
-        """
-        Documenting to see return type.
-
-        Return:
-            The object with all its children populated.
-        """
-        module, obj = import_object(import_string)
-        path = module.__name__
-        if inspect.ismodule(obj):
-            root_object = self.get_module_documentation(obj, path)
-        elif inspect.isclass(obj):
-            path = f"{path}.{obj.__name__}"
-            root_object = self.get_class_documentation(obj, path)
-        elif inspect.isfunction(obj):
-            path = f"{path}.{obj.__name__}"
-            root_object = self.get_function_documentation(obj, path)
-        else:
-            raise ValueError(f"{obj}:{type(obj)} not yet supported")
-        attributes = get_attributes(module)
-        root_object.dispatch_attributes([a for a in attributes if not self.filter_name_out(a.name)])
-        return root_object
-
-    def get_module_documentation(self, module: ModuleType, path: str) -> Object:
-        module_name = path.split(".")[-1]
-        module_file_basename = os.path.splitext(os.path.basename(module.__file__))[0]
-        properties = get_name_properties(module_file_basename, CATEGORY_MODULE)
-        root_object = Object(
-            category=CATEGORY_MODULE,
-            name=module_name,
-            path=path,
-            docstring=inspect.getdoc(module),
-            properties=properties,
-        )
-        for member_name, member in inspect.getmembers(module):
-            if self.filter_name_out(member_name):
-                continue
-            member_path = f"{path}.{member_name}"
-            if inspect.isclass(member) and inspect.getmodule(member) == module:
-                root_object.add_child(self.get_class_documentation(member, member_path))
-            elif inspect.isfunction(member) and inspect.getmodule(member) == module:
-                root_object.add_child(self.get_function_documentation(member, member_path))
-        return root_object
-
-    def get_class_documentation(self, class_: Type[Any], path: str) -> Object:
-        class_name = class_.__name__
-        root_object = Object(
-            category=CATEGORY_CLASS,
-            name=class_name,
-            path=path,
-            docstring=inspect.getdoc(class_),
-            properties=get_name_properties(class_name, CATEGORY_CLASS),
-            signature=inspect.signature(class_),
-        )
-        for member_name, member in sorted(class_.__dict__.items()):
-            if self.filter_name_out(member_name):
-                continue
-            member_path = f"{path}.{member_name}"
-            if inspect.isclass(member):
-                root_object.add_child(self.get_class_documentation(member, member_path))
-                continue
-
-            actual_member = getattr(class_, member_name)
-            docstring = inspect.getdoc(actual_member)
-            try:
-                source = inspect.getsourcelines(actual_member)
-            except TypeError:
-                source = ""
-            if isinstance(member, classmethod):
-                root_object.add_child(
-                    Object(
-                        category=CATEGORY_METHOD,
-                        name=member_name,
-                        path=member_path,
-                        docstring=docstring,
-                        properties=get_name_properties(member_name, CATEGORY_METHOD) + ["classmethod"],
-                        source=source,
-                        signature=inspect.signature(actual_member),
-                    )
-                )
-            elif isinstance(member, staticmethod):
-                root_object.add_child(
-                    Object(
-                        category=CATEGORY_METHOD,
-                        name=member_name,
-                        path=member_path,
-                        docstring=docstring,
-                        properties=get_name_properties(member_name, CATEGORY_METHOD) + ["staticmethod"],
-                        source=source,
-                        signature=inspect.signature(actual_member),
-                    )
-                )
-            elif isinstance(member, type(lambda: 0)):  # regular method
-                root_object.add_child(
-                    Object(
-                        category=CATEGORY_METHOD,
-                        name=member_name,
-                        path=member_path,
-                        docstring=docstring,
-                        properties=get_name_properties(member_name, CATEGORY_METHOD),
-                        source=source,
-                        signature=inspect.signature(actual_member),
-                    )
-                )
-            elif isinstance(member, property):
-                properties = ["property"]
-                if member.fset is None:
-                    properties.append("readonly")
-                root_object.add_child(
-                    Object(
-                        category=CATEGORY_ATTRIBUTE,
-                        name=member_name,
-                        path=member_path,
-                        docstring=docstring,
-                        properties=properties + get_name_properties(member_name, CATEGORY_ATTRIBUTE),
-                        source=source,
-                        signature=inspect.signature(actual_member.fget),
-                    )
-                )
-        return root_object
-
-    def get_function_documentation(self, function: Callable, path: str) -> Object:
-        function_name = function.__name__
-        return Object(
-            category=CATEGORY_FUNCTION,
-            name=function_name,
-            path=path,
-            docstring=inspect.getdoc(function),
-            properties=get_name_properties(function_name, CATEGORY_FUNCTION),
-            source=inspect.getsourcelines(function),
-            signature=inspect.signature(function),
-        )
-
-    @lru_cache(maxsize=None)
-    def filter_name_out(self, name: str) -> bool:
-        keep = True
-        for f, regex in self.global_filters:
-            is_matching = bool(regex.match(name))
-            if is_matching:
-                if str(f).startswith("!"):
-                    is_matching = not is_matching
-                keep = is_matching
-        return not keep

--- a/src/mkdocstrings/plugin.py
+++ b/src/mkdocstrings/plugin.py
@@ -5,30 +5,6 @@ from mkdocs.plugins import BasePlugin
 
 from .documenter import Documenter
 
-# TODO: show source file in source code blocks titles
-
-# TODO: option to change initial heading level per autodoc instruction
-
-# TODO: use type annotations
-
-# TODO: support more properties:
-#       generators, coroutines, awaitable (see inspect.is...), decorators?
-#       metaclass, dataclass
-#       optional (parameters with default values)
-
-# TODO: pick attributes without docstrings?
-
-# TODO: write tests
-
-# TODO: make sure to recurse correctly (module's modules, class' classes, etc.)
-# TODO: discover package's submodules
-
-# TODO: option to void special methods' docstrings
-#       when they are equal to the built-in ones (ex: "Return str(self)." for __str__)
-
-# TODO: option not to write root group header if it's the only group
-# TODO: option to move __init__ docstring to class docstring
-
 config = {
     "show_top_object_heading": False,
     "show_top_object_full_path": True,
@@ -85,13 +61,12 @@ class MkdocstringsPlugin(BasePlugin):
         lines = markdown.split("\n")
         modified_lines = lines[::]
         for i, line in enumerate(lines):
-            # if line.startswith("<p>::: ") or line.startswith("::: "):
+            config_copy = dict(config)
             if line.startswith("::: "):
                 import_string = line.replace("::: ", "")
-                # import_string = line.replace("::: ", "").replace("<p>", "").replace("</p>", "")
                 root_object = self.objects[import_string]["object"]
-                heading = 2 if config["show_top_object_heading"] else 1
-                new_lines = root_object.render(heading, **config)
+                heading = 2 if config_copy["show_top_object_heading"] else 1
+                new_lines = root_object.render(heading, config_copy)
                 modified_lines[i] = new_lines
         modified_lines.extend(self.references)
         return "\n".join(modified_lines)


### PR DESCRIPTION
This PR does a refactor of the code to make it more readable and robust.

We removed the "categories" and re-implemented them using subclasses of `Object`.

This PR also adds a feature: the signature (or type annotation) for attributes.

The next commits will refactor the functions related to signatures and parameters.