### PR TITLE
handle unparsable line more nicely

### DIFF
--- a/README.md
+++ b/README.md
@@ -149,8 +149,8 @@ def my_function(param1: int, param2: Optional[str] = None) -> str:
                They will all be concatenated in one line, so do not try to
              use complex markup here.
 
-    Important:
-        Note how we omitted the type hints next to the parameters names.
+    Note:
+        We omitted the type hints next to the parameters names.
         Usually you would write something like `param1 (int): ...`,
         but `mkdocstrings` gets the type information from the signature, so it's not needed here.
 
@@ -162,7 +162,7 @@ def my_function(param1: int, param2: Optional[str] = None) -> str:
           Multi-line description, etc.
 
     Let's see the return value section now.
-    
+
     Returns:
         A description of the value that is returned.
         Again multiple lines are allowed. They will also be concatenated to one line,
@@ -170,7 +170,7 @@ def my_function(param1: int, param2: Optional[str] = None) -> str:
 
     Note:
         Other words are supported:
-        
+
         - `Args`, `Arguments`, `Params` and `Parameters` for the parameters.
         - `Raise`, `Raises`, `Except`, and `Exceptions` for exceptions.
         - `Return` or `Returns` for return value.

--- a/src/mkdocstrings/docstrings.py
+++ b/src/mkdocstrings/docstrings.py
@@ -211,7 +211,11 @@ class Docstring:
         parameters = []
         block, i = self.read_block_items(lines, start_index)
         for param_line in block:
-            name, description = param_line.lstrip(" ").split(":", 1)
+            try:
+                name, description = param_line.lstrip(" ").split(":", 1)
+            except Exception as e:
+                print(f"Failed to get 'name: description' pair from '{param_line}'")
+                continue
             try:
                 signature_param = self.signature.parameters[name]
             except AttributeError:

--- a/src/mkdocstrings/docstrings.py
+++ b/src/mkdocstrings/docstrings.py
@@ -44,6 +44,7 @@ TITLES_RETURN = ("return:", "returns:")
 
 RE_OPTIONAL = re.compile(r"Union\[(.+), NoneType\]")
 RE_FORWARD_REF = re.compile(r"_ForwardRef\('([^']+)'\)")
+RE_EMPTY = re.compile(r"_empty")
 
 
 class AnnotatedObject:
@@ -82,8 +83,9 @@ class Parameter(AnnotatedObject):
     @property
     def annotation_string(self):
         s = AnnotatedObject.annotation_string.fget(self)
+        s = RE_EMPTY.sub("", s)
+        s = RE_OPTIONAL.sub(lambda match: match.group(1), s)
         s = RE_FORWARD_REF.sub(lambda match: match.group(1), s)
-        s = RE_OPTIONAL.sub(lambda match: f"Optional[{rebuild_optional(match.group(1))}]", s)
         return s
 
     @property

--- a/src/mkdocstrings/docstrings.py
+++ b/src/mkdocstrings/docstrings.py
@@ -214,7 +214,14 @@ class Docstring:
         block, i = self.read_block_items(lines, start_index)
         for param_line in block:
             try:
-                name, description = param_line.lstrip(" ").split(":", 1)
+                name_with_type, description = param_line.lstrip(" ").split(":", 1)
+                paren_index = name_with_type.find("(")
+                if paren_index != -1:
+                    # name (type)
+                    name = name_with_type[0:paren_index].strip()
+                else:
+                    # no type, just use name as-is
+                    name = name_with_type
             except Exception as e:
                 print(f"Failed to get 'name: description' pair from '{param_line}'")
                 continue

--- a/src/mkdocstrings/documenter.py
+++ b/src/mkdocstrings/documenter.py
@@ -342,12 +342,13 @@ class Documenter:
         class_name = class_.__name__
         path = f"{module.__name__}.{class_name}"
         file_path = module.__file__
-        root_object = Class(
-            name=class_name,
-            path=path,
-            file_path=file_path,
-            docstring=Docstring(textwrap.dedent(class_.__doc__ or ""), inspect.signature(class_)),
-        )
+        try:
+            signature = inspect.signature(class_)
+        except ValueError:
+            print(f"Failed to get signature for {class_name}")
+            signature = inspect.Signature()
+        docstring = Docstring(textwrap.dedent(class_.__doc__ or ""),)
+        root_object = Class(name=class_name, path=path, file_path=file_path, docstring=docstring,)
 
         for member_name, member in sorted(filter(lambda m: not self.filter_name_out(m[0]), class_.__dict__.items())):
             if inspect.isclass(member):

--- a/src/mkdocstrings/renderer.py
+++ b/src/mkdocstrings/renderer.py
@@ -113,7 +113,8 @@ def render_docstring(obj, lines):
                     name = f"*{name}"
                 default = parameter.default_string
                 default = f"`{default}`" if default else "*required*"
-                lines.append(f"| `{name}` | `{parameter.annotation_string}` | {parameter.description} | {default} |")
+                type_annotation = f"`{parameter.annotation_string}`" if parameter.annotation_string else ""
+                lines.append(f"| `{name}` | {type_annotation} | {parameter.description} | {default} |")
             lines.append("")
         elif section.type == Section.Type.EXCEPTIONS:
             lines.append("**Exceptions**\n")


### PR DESCRIPTION
My docstring:
```
        Args:
            read_response: Block and read response. If there is a separate thread running,
            this can be false, and the reading thread can read the output.
```

(it should have had an indent at `this`)

mkdocstrings out put (Before):
```
INFO    -  Building documentation... 
[E 200125 14:38:21 ioloop:909] Exception in callback <bound method LiveReloadHandler.poll_tasks of <class 'livereload.handlers.LiveReloadHandler'>>
    Traceback (most recent call last):
      File "/home/csmith/git/pygdbmi/.nox/serve_docs/lib/python3.6/site-packages/tornado/ioloop.py", line 907, in _run
        return self.callback()
      File "/home/csmith/git/pygdbmi/.nox/serve_docs/lib/python3.6/site-packages/livereload/handlers.py", line 69, in poll_tasks
        filepath, delay = cls.watcher.examine()
      File "/home/csmith/git/pygdbmi/.nox/serve_docs/lib/python3.6/site-packages/livereload/watcher.py", line 105, in examine
        func()
      File "/home/csmith/git/pygdbmi/.nox/serve_docs/lib/python3.6/site-packages/mkdocs/commands/serve.py", line 114, in builder
        build(config, live_server=live_server, dirty=dirty)
      File "/home/csmith/git/pygdbmi/.nox/serve_docs/lib/python3.6/site-packages/mkdocs/commands/build.py", line 270, in build
        nav = config['plugins'].run_event('nav', nav, config=config, files=files)
      File "/home/csmith/git/pygdbmi/.nox/serve_docs/lib/python3.6/site-packages/mkdocs/plugins.py", line 94, in run_event
        result = method(item, **kwargs)
      File "/home/csmith/git/pygdbmi/.nox/serve_docs/lib/python3.6/site-packages/mkdocstrings/plugin.py", line 110, in on_nav
        root_object = self.documenter.get_object_documentation(import_string)
      File "/home/csmith/git/pygdbmi/.nox/serve_docs/lib/python3.6/site-packages/mkdocstrings/documenter.py", line 307, in get_object_documentation
        root_object = self.get_class_documentation(obj, module)
      File "/home/csmith/git/pygdbmi/.nox/serve_docs/lib/python3.6/site-packages/mkdocstrings/documenter.py", line 399, in get_class_documentation
        docstring=Docstring(docstring, signature),
      File "/home/csmith/git/pygdbmi/.nox/serve_docs/lib/python3.6/site-packages/mkdocstrings/docstrings.py", line 117, in __init__
        self.blocks = self.parse()
      File "/home/csmith/git/pygdbmi/.nox/serve_docs/lib/python3.6/site-packages/mkdocstrings/docstrings.py", line 152, in parse
        section, i = self.read_parameters_section(lines, i + 1)
      File "/home/csmith/git/pygdbmi/.nox/serve_docs/lib/python3.6/site-packages/mkdocstrings/docstrings.py", line 214, in read_parameters_section
        name, description = param_line.lstrip(" ").split(":", 1)
    ValueError: not enough values to unpack (expected 2, got 1)
```

mkdocstrings out put (After)::
```
Failed to get 'name: description' pair from '    this can be false, and the reading thread can read the output.'
```

Ideally the error message would also contain the filename and function/class name as well.

I briefly looked around the tests and saw the fixtures were all empty. Any tips on the best way to test this change?