### PR TITLE
handle types in docstring args, Exception types

### DIFF
--- a/README.md
+++ b/README.md
@@ -149,8 +149,8 @@ def my_function(param1: int, param2: Optional[str] = None) -> str:
                They will all be concatenated in one line, so do not try to
              use complex markup here.
 
-    Important:
-        Note how we omitted the type hints next to the parameters names.
+    Note:
+        We omitted the type hints next to the parameters names.
         Usually you would write something like `param1 (int): ...`,
         but `mkdocstrings` gets the type information from the signature, so it's not needed here.
 
@@ -162,7 +162,7 @@ def my_function(param1: int, param2: Optional[str] = None) -> str:
           Multi-line description, etc.
 
     Let's see the return value section now.
-    
+
     Returns:
         A description of the value that is returned.
         Again multiple lines are allowed. They will also be concatenated to one line,
@@ -170,7 +170,7 @@ def my_function(param1: int, param2: Optional[str] = None) -> str:
 
     Note:
         Other words are supported:
-        
+
         - `Args`, `Arguments`, `Params` and `Parameters` for the parameters.
         - `Raise`, `Raises`, `Except`, and `Exceptions` for exceptions.
         - `Return` or `Returns` for return value.

--- a/src/mkdocstrings/docstrings.py
+++ b/src/mkdocstrings/docstrings.py
@@ -212,7 +212,14 @@ class Docstring:
         block, i = self.read_block_items(lines, start_index)
         for param_line in block:
             try:
-                name, description = param_line.lstrip(" ").split(":", 1)
+                name_with_type, description = param_line.lstrip(" ").split(":", 1)
+                paren_index = name_with_type.find("(")
+                if paren_index != -1:
+                    # name (type)
+                    name = name_with_type[0:paren_index].strip()
+                else:
+                    # no type, just use name as-is
+                    name = name_with_type
             except Exception as e:
                 print(f"Failed to get 'name: description' pair from '{param_line}'")
                 continue

--- a/src/mkdocstrings/docstrings.py
+++ b/src/mkdocstrings/docstrings.py
@@ -211,7 +211,11 @@ class Docstring:
         parameters = []
         block, i = self.read_block_items(lines, start_index)
         for param_line in block:
-            name, description = param_line.lstrip(" ").split(":", 1)
+            try:
+                name, description = param_line.lstrip(" ").split(":", 1)
+            except Exception as e:
+                print(f"Failed to get 'name: description' pair from '{param_line}'")
+                continue
             try:
                 signature_param = self.signature.parameters[name]
             except AttributeError:

--- a/src/mkdocstrings/documenter.py
+++ b/src/mkdocstrings/documenter.py
@@ -347,7 +347,7 @@ class Documenter:
         except ValueError:
             print(f"Failed to get signature for {class_name}")
             signature = inspect.Signature()
-        docstring = Docstring(textwrap.dedent(class_.__doc__ or ""),)
+        docstring = Docstring(textwrap.dedent(class_.__doc__ or ""), signature)
         root_object = Class(name=class_name, path=path, file_path=file_path, docstring=docstring,)
 
         for member_name, member in sorted(filter(lambda m: not self.filter_name_out(m[0]), class_.__dict__.items())):

--- a/src/mkdocstrings/documenter.py
+++ b/src/mkdocstrings/documenter.py
@@ -342,12 +342,13 @@ class Documenter:
         class_name = class_.__name__
         path = f"{module.__name__}.{class_name}"
         file_path = module.__file__
-        root_object = Class(
-            name=class_name,
-            path=path,
-            file_path=file_path,
-            docstring=Docstring(textwrap.dedent(class_.__doc__ or ""), inspect.signature(class_)),
-        )
+        try:
+            signature = inspect.signature(class_)
+        except ValueError:
+            print(f"Failed to get signature for {class_name}")
+            signature = inspect.Signature()
+        docstring = Docstring(textwrap.dedent(class_.__doc__ or ""),)
+        root_object = Class(name=class_name, path=path, file_path=file_path, docstring=docstring,)
 
         for member_name, member in sorted(filter(lambda m: not self.filter_name_out(m[0]), class_.__dict__.items())):
             if inspect.isclass(member):


### PR DESCRIPTION
Fix 1:
The signature cannot be determined from this code.
```
class MyError(ValueError):
    """Raise when trying to ..."""

    pass
```

 This PR uses an empty signature when signature cannot be determined. 

Fix 2:
When a docstring for arguments has a type hint, an error would be thrown. This PR strips out text in parentheses from the argument name, and allows documentation to be successfully generated.

(Unfortunately I do not have the time to write full tests for these fixes, but wanted to share them anyway)