### PR TITLE
do not render empty types

### DIFF
--- a/src/mkdocstrings/docstrings.py
+++ b/src/mkdocstrings/docstrings.py
@@ -44,7 +44,6 @@ TITLES_RETURN = ("return:", "returns:")
 
 RE_OPTIONAL = re.compile(r"Union\[(.+), NoneType\]")
 RE_FORWARD_REF = re.compile(r"_ForwardRef\('([^']+)'\)")
-RE_EMPTY = re.compile(r"_empty")
 
 
 class AnnotatedObject:
@@ -83,9 +82,8 @@ class Parameter(AnnotatedObject):
     @property
     def annotation_string(self):
         s = AnnotatedObject.annotation_string.fget(self)
-        s = RE_EMPTY.sub("", s)
-        s = RE_OPTIONAL.sub(lambda match: match.group(1), s)
         s = RE_FORWARD_REF.sub(lambda match: match.group(1), s)
+        s = RE_OPTIONAL.sub(lambda match: f"Optional[{rebuild_optional(match.group(1))}]", s)
         return s
 
     @property

--- a/src/mkdocstrings/docstrings.py
+++ b/src/mkdocstrings/docstrings.py
@@ -44,6 +44,7 @@ TITLES_RETURN = ("return:", "returns:")
 
 RE_OPTIONAL = re.compile(r"Union\[(.+), NoneType\]")
 RE_FORWARD_REF = re.compile(r"_ForwardRef\('([^']+)'\)")
+RE_EMPTY = re.compile(r"_empty")
 
 
 class AnnotatedObject:
@@ -82,8 +83,9 @@ class Parameter(AnnotatedObject):
     @property
     def annotation_string(self):
         s = AnnotatedObject.annotation_string.fget(self)
+        s = RE_EMPTY.sub("", s)
+        s = RE_OPTIONAL.sub(lambda match: match.group(1), s)
         s = RE_FORWARD_REF.sub(lambda match: match.group(1), s)
-        s = RE_OPTIONAL.sub(lambda match: f"Optional[{rebuild_optional(match.group(1))}]", s)
         return s
 
     @property

--- a/src/mkdocstrings/renderer.py
+++ b/src/mkdocstrings/renderer.py
@@ -113,7 +113,8 @@ def render_docstring(obj, lines):
                     name = f"*{name}"
                 default = parameter.default_string
                 default = f"`{default}`" if default else "*required*"
-                lines.append(f"| `{name}` | `{parameter.annotation_string}` | {parameter.description} | {default} |")
+                type_annotation = f"`{parameter.annotation_string}`" if parameter.annotation_string else ""
+                lines.append(f"| `{name}` | {type_annotation} | {parameter.description} | {default} |")
             lines.append("")
         elif section.type == Section.Type.EXCEPTIONS:
             lines.append("**Exceptions**\n")

--- a/src/mkdocstrings/utils.py
+++ b/src/mkdocstrings/utils.py
@@ -9,6 +9,8 @@ except ImportError:
 
 
 def annotation_to_string(annotation):
+    if annotation is inspect.Signature.empty:
+        return ""
     if inspect.isclass(annotation) and not isinstance(annotation, GenericMeta):
         return annotation.__name__
     return str(annotation).replace("typing.", "")


### PR DESCRIPTION
If there is no type associated with an argument, display an empty table cell rather than the word `_empty`.

fixes #34