### PR TITLE
Do not reload numpy

### DIFF
--- a/src/mkdocstrings/plugin.py
+++ b/src/mkdocstrings/plugin.py
@@ -80,6 +80,8 @@ class MkdocstringsPlugin(BasePlugin):
                 f"mkdocstrings: Unloading modules loaded after mkdocstrings plugin was instantiated ({len(diff)} modules)"
             )
             for module in diff:
+                if "numpy" in module:
+                    continue
                 del sys.modules[module]
             self.clear()
             builder()


### PR DESCRIPTION
Temporary workaround to prevent numpy from being reloaded when live watching locally.

See issue raised at https://github.com/pawamoy/mkdocstrings/issues/36#issuecomment-594495481 for more details.

