### PR TITLE
s/name/path to enable loading of nested modules

### DIFF
--- a/src/mkdocstrings/documenter.py
+++ b/src/mkdocstrings/documenter.py
@@ -339,7 +339,7 @@ class Documenter:
         else:
             for _, modname, _ in pkgutil.iter_modules(package_path):
                 if not self.filter_name_out(modname):
-                    parent, submodule = import_object(f"{name}.{modname}")
+                    parent, submodule = import_object(f"{path}.{modname}")
                     root_object.add_child(self.get_module_documentation(submodule))
 
         return root_object


### PR DESCRIPTION
Hi,

the current behavior fails to load submodules that are 3 levels deep. Say there is a module named `a.b.c`. When processing `a.b` name gets set to `b` and then `import_object(b.c)` is called, which fails. After the change `import_object(a.b.c)` is called, which works.

