### PR TITLE
fix: mkdocstrings unable to parse custom theme directory configuration

### DIFF
--- a/src/mkdocstrings/plugin.py
+++ b/src/mkdocstrings/plugin.py
@@ -23,9 +23,9 @@ during the [`on_serve` event hook](https://www.mkdocs.org/user-guide/plugins/#on
 """
 
 import logging
+import os
 import random
 import re
-import os
 import string
 from typing import Any, Callable, Dict, List, Match, Optional, Pattern, Tuple
 

--- a/src/mkdocstrings/plugin.py
+++ b/src/mkdocstrings/plugin.py
@@ -25,6 +25,7 @@ during the [`on_serve` event hook](https://www.mkdocs.org/user-guide/plugins/#on
 import logging
 import random
 import re
+import os
 import string
 from typing import Any, Callable, Dict, List, Match, Optional, Pattern, Tuple
 
@@ -151,8 +152,14 @@ class MkdocstringsPlugin(BasePlugin):
 
         log.debug("mkdocstrings.plugin: Adding extension to the list")
 
+        theme_name = None
+        if config["theme"].name is None:
+            theme_name = os.path.dirname(config["theme"].dirs[0])
+        else:
+            theme_name = config["theme"].name
+
         extension_config = {
-            "theme_name": config["theme"].name,
+            "theme_name": theme_name,
             "mdx": config["markdown_extensions"],
             "mdx_configs": config["mdx_configs"],
             "mkdocstrings": self.config,


### PR DESCRIPTION
This PR adds support for mkdocs-material's custom_dir configuration, where theme `name` is set to null in mkdocs.yaml. Thereby,  it adds support to automatically read out the required theme_name from `dirs` attribute, only if `name` attribute is None(or null), otherwise default behaviour will occur.

Fixes #120.