### PR TITLE
Update pymdown-extensions requirement

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,7 +22,7 @@ include = [
 python = "^3.6"
 beautifulsoup4 = "^4.8.2"
 mkdocs = "^1.1"
-pymdown-extensions = ">=6.3, <8.0"
+pymdown-extensions = ">=6.3, <9.0"
 pytkdocs = ">=0.2.0, <0.8.0"
 
 [tool.poetry.dev-dependencies]


### PR DESCRIPTION
PyMdown Extensions 8.0 has been released:

* https://facelessuser.github.io/pymdown-extensions/about/releases/8.0/#8.0
* https://pypi.org/project/pymdown-extensions/8.0/

Update the version range to allow version 8.