### PR TITLE
Bring back arbitrary **config to Python handler

### DIFF
--- a/src/mkdocstrings/handlers/python.py
+++ b/src/mkdocstrings/handlers/python.py
@@ -246,10 +246,10 @@ class PythonHandler(BaseHandler):
 
 
 def get_handler(
-    theme: str,
+    theme: str,  # noqa: W0613 (unused argument config)
     custom_templates: Optional[str] = None,
     setup_commands: Optional[List[str]] = None,
-    **config: Any,  # noqa: W0613
+    **config: Any,
 ) -> PythonHandler:
     """
     Simply return an instance of `PythonHandler`.

--- a/src/mkdocstrings/handlers/python.py
+++ b/src/mkdocstrings/handlers/python.py
@@ -249,6 +249,7 @@ def get_handler(
     theme: str,
     custom_templates: Optional[str] = None,
     setup_commands: Optional[List[str]] = None,
+    **kwargs: Any,
 ) -> PythonHandler:
     """
     Simply return an instance of `PythonHandler`.

--- a/src/mkdocstrings/handlers/python.py
+++ b/src/mkdocstrings/handlers/python.py
@@ -249,7 +249,7 @@ def get_handler(
     theme: str,
     custom_templates: Optional[str] = None,
     setup_commands: Optional[List[str]] = None,
-    **kwargs: Any,
+    **config: Any,  # noqa: W0613
 ) -> PythonHandler:
     """
     Simply return an instance of `PythonHandler`.
@@ -258,6 +258,7 @@ def get_handler(
         theme: The theme to use when rendering contents.
         custom_templates: Directory containing custom templates.
         setup_commands: A list of commands as strings to be executed in the subprocess before `pytkdocs`.
+        config: Configuration passed to the handler.
 
     Returns:
         An instance of `PythonHandler`.


### PR DESCRIPTION
Closes #154

I'm not sure if this is what we want, or if we want to _not_ pass `**config` in the parent `get_handler()` implementation, but either of these should resolve the bug showcased in #154.

https://github.com/florimondmanca/mkdocstrings/blob/25373148699daad42b319fa04213d405ca8a7c4c/src/mkdocstrings/handlers/__init__.py#L244

---

PS: I wasn't able to run `make setup` (I don't have 3.6 and 3.7 installed, and pinning `PYTHON_VERSIONS = ("3.8",)` results in a strange error I couldn't find the cause of…

```console
$ make setup
Setting up Python 3.8 environment
---------------------------------
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
NameError: name 'PosixPath' is not defined
make: *** [setup] Error 1
```