### PR TITLE
feat: Allow specifying heading_level as a Markdown heading instead

### DIFF
--- a/docs/usage.md
+++ b/docs/usage.md
@@ -82,6 +82,23 @@ Check the documentation for your handler of interest in [Handlers](../handlers/o
         method_b<span class="p">(</span><span class="bp">self</span><span class="p">)</span> </code>
         </h4><div><p>Print B!</p></div></div></div></div></div>
 
+It is also possible to integrate a mkdocstrings identifier into a Markdown header:
+
+```md
+## ::: my_package.my_module.MyClass
+    rendering:
+      show_source: false
+```
+
+The above is equivalent to:
+
+```md
+::: my_package.my_module.MyClass
+    rendering:
+      show_source: false
+      heading_level: 2
+```
+
 
 
 ## Global options

--- a/src/mkdocstrings/extension.py
+++ b/src/mkdocstrings/extension.py
@@ -190,7 +190,7 @@ class AutoDocProcessor(BlockProcessor):
 
         selection, rendering = get_item_configs(handler_config, config)
         if heading_level:
-            rendering.setdefault("heading_level", heading_level)
+            rendering = ChainMap(rendering, {"heading_level": heading_level})  # like setdefault
 
         log.debug("Collecting data")
         try:


### PR DESCRIPTION
This also refactors the regex to use the `MULTILINE` flag instead of the complex "manual" alternative for detecting newlines.