### PR TITLE
feat: Allow any characters in identifiers

### DIFF
--- a/src/mkdocstrings/extension.py
+++ b/src/mkdocstrings/extension.py
@@ -91,7 +91,7 @@ class AutoDocProcessor(BlockProcessor):
     """
 
     classname = "autodoc"
-    regex = re.compile(r"(?:^|\n)::: ?([:a-zA-Z0-9_.-]*) *(?:\n|$)")
+    regex = re.compile(r"(?:^|\n)::: ?(.+?) *(?:\n|$)")
 
     def __init__(self, parser: BlockParser, md: Markdown, config: dict) -> None:
         """


### PR DESCRIPTION
The current character set currently seems tailored to the Python handler, but can be not enough for others
(example identifier for a planned Crystal handler: `Foo::Type#bar(a,b)`)

And it doesn't seem like there's any strong reason to limit these?