### PR TITLE
Rework autorefs replacement to not re-parse the final HTML

### DIFF
--- a/CREDITS.md
+++ b/CREDITS.md
@@ -11,7 +11,6 @@ These projects were used to build `mkdocstrings`. **Thank you!**
 
 ### Direct dependencies
 [`autoflake`](https://github.com/myint/autoflake) |
-[`beautifulsoup4`](http://www.crummy.com/software/BeautifulSoup/bs4/) |
 [`black`](https://github.com/psf/black) |
 [`coverage`](https://github.com/nedbat/coveragepy) |
 [`failprint`](https://github.com/pawamoy/failprint) |
@@ -127,7 +126,6 @@ These projects were used to build `mkdocstrings`. **Thank you!**
 [`smmap`](https://github.com/gitpython-developers/smmap) |
 [`sniffio`](https://github.com/python-trio/sniffio) |
 [`snowballstemmer`](https://github.com/snowballstem/snowball) |
-[`soupsieve`](https://github.com/facelessuser/soupsieve) |
 [`stevedore`](https://docs.openstack.org/stevedore/latest/) |
 [`termcolor`](http://pypi.python.org/pypi/termcolor) |
 [`testfixtures`](https://github.com/Simplistix/testfixtures) |

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,7 +20,7 @@ include = [
 
 [tool.poetry.dependencies]
 python = "^3.6"
-beautifulsoup4 = "^4.8.2"
+Markdown = "^3.3"
 mkdocs = "^1.1"
 pymdown-extensions = ">=6.3, <9.0"
 pytkdocs = ">=0.2.0, <0.10.0"

--- a/src/mkdocstrings/extension.py
+++ b/src/mkdocstrings/extension.py
@@ -37,6 +37,7 @@ from markdown.util import AtomicString
 
 from mkdocstrings.handlers.base import CollectionError, get_handler
 from mkdocstrings.loggers import get_logger
+from mkdocstrings.references import AutoRefInlineProcessor
 
 log = get_logger(__name__)
 
@@ -302,6 +303,7 @@ class MkdocstringsExtension(Extension):
     """
 
     blockprocessor_priority = 75  # Right before markdown.blockprocessors.HashHeaderProcessor
+    inlineprocessor_priority = 168  # Right after markdown.inlinepatterns.ReferenceInlineProcessor
 
     def __init__(self, config: dict, **kwargs) -> None:
         """
@@ -327,3 +329,5 @@ class MkdocstringsExtension(Extension):
         md.registerExtension(self)
         processor = AutoDocProcessor(md.parser, md, self._config)
         md.parser.blockprocessors.register(processor, "mkdocstrings", self.blockprocessor_priority)
+        ref_processor = AutoRefInlineProcessor(md)
+        md.inlinePatterns.register(ref_processor, "mkdocstrings", self.inlineprocessor_priority)

--- a/tests/fixtures/cross_reference.py
+++ b/tests/fixtures/cross_reference.py
@@ -1,0 +1,3 @@
+"""
+Link to [something.Else][].
+"""

--- a/tests/test_extension.py
+++ b/tests/test_extension.py
@@ -1,17 +1,29 @@
 """Tests for the extension module."""
-
 from markdown import Markdown
 
 from mkdocstrings.extension import MkdocstringsExtension
 
+_DEFAULT_CONFIG = {
+    "theme_name": "material",
+    "mdx": [],
+    "mdx_configs": {},
+    "mkdocstrings": {"default_handler": "python", "custom_templates": None, "watch": [], "handlers": {}},
+}
+
 
 def test_render_html_escaped_sequences():
     """Assert HTML-escaped sequences are correctly parsed as XML."""
-    config = {
-        "theme_name": "material",
-        "mdx": [],
-        "mdx_configs": {},
-        "mkdocstrings": {"default_handler": "python", "custom_templates": None, "watch": [], "handlers": {}},
-    }
-    md = Markdown(extensions=[MkdocstringsExtension(config)])
+    md = Markdown(extensions=[MkdocstringsExtension(_DEFAULT_CONFIG)])
     md.convert("::: tests.fixtures.html_escaped_sequences")
+
+
+def test_reference_inside_autodoc():
+    config = dict(_DEFAULT_CONFIG)
+    ext = MkdocstringsExtension(config)
+    config["mdx"].append(ext)
+
+    md = Markdown(extensions=[ext])
+
+    output = md.convert("::: tests.fixtures.cross_reference")
+    snippet = 'Link to <span data-mkdocstrings-identifier="something.Else">something.Else</span>.'
+    assert snippet in output

--- a/tests/test_references.py
+++ b/tests/test_references.py
@@ -1,8 +1,9 @@
 """Tests for the references module."""
+import markdown
 import pytest
-from bs4 import BeautifulSoup
 
-from mkdocstrings.references import Placeholder, relative_url
+from mkdocstrings.extension import MkdocstringsExtension
+from mkdocstrings.references import fix_refs, relative_url
 
 
 @pytest.mark.parametrize(
@@ -37,19 +38,86 @@ def test_relative_url(current_url, to_url, href_url):
     assert relative_url(current_url, to_url) == href_url
 
 
-@pytest.mark.parametrize("html", ["foo<code>code content</code>4"])
-def test_placeholder(html):
-    """
-    Test the references "fixing" mechanism.
+def run_references_test(url_map, source, output, unmapped=None, from_url="page.html"):
+    ext = MkdocstringsExtension({})
+    md = markdown.Markdown(extensions=[ext])
+    content = md.convert(source)
+    actual_output, actual_unmapped = fix_refs(content, from_url, url_map)
+    assert actual_output == output
+    assert actual_unmapped == (unmapped or [])
 
-    Arguments:
-        html: HTML contents in which to fix references.
-    """
-    placeholder = Placeholder()
 
-    soup = BeautifulSoup(html, "html.parser")
-    placeholder.replace_code_tags(soup)
-    html_with_placeholders = str(soup).replace("code content", "should not be replaced")
+def test_reference_implicit():
+    run_references_test(
+        url_map={"Foo": "foo.html#Foo"},
+        source="This [Foo][].",
+        output='<p>This <a href="foo.html#Foo">Foo</a>.</p>',
+    )
 
-    html_restored = placeholder.restore_code_tags(html_with_placeholders)
-    assert html == html_restored
+
+def test_reference_explicit_with_markdown_text():
+    run_references_test(
+        url_map={"Foo": "foo.html#Foo"},
+        source="This [`Foo`][Foo].",
+        output='<p>This <a href="foo.html#Foo"><code>Foo</code></a>.</p>',
+    )
+
+
+def test_reference_with_punctuation():
+    run_references_test(
+        url_map={'Foo&"bar': 'foo.html#Foo&"bar'},
+        source='This [Foo&"bar][].',
+        output='<p>This <a href="foo.html#Foo&amp;&quot;bar">Foo&amp;"bar</a>.</p>',
+    )
+
+
+def test_no_reference_with_space():
+    run_references_test(
+        url_map={"Foo bar": "foo.html#Foo bar"},
+        source="This `[Foo bar][]`.",
+        output="<p>This <code>[Foo bar][]</code>.</p>",
+    )
+
+
+def test_no_reference_inside_markdown():
+    run_references_test(
+        url_map={"Foo": "foo.html#Foo"},
+        source="This `[Foo][]`.",
+        output="<p>This <code>[Foo][]</code>.</p>",
+    )
+
+
+def test_missing_reference():
+    run_references_test(
+        url_map={"NotFoo": "foo.html#NotFoo"},
+        source="[Foo][]",
+        output="<p>[Foo][]</p>",
+        unmapped=["Foo"],
+    )
+
+
+def test_missing_reference_with_markdown_text():
+    run_references_test(
+        url_map={"NotFoo": "foo.html#NotFoo"},
+        source="[`Foo`][Foo]",
+        output="<p>[<code>Foo</code>][Foo]</p>",
+        unmapped=["Foo"],
+    )
+
+
+def test_missing_reference_with_markdown_id():
+    run_references_test(
+        url_map={"NotFoo": "foo.html#NotFoo"},
+        source="[Foo][*oh*]",
+        output="<p>[Foo][*oh*]</p>",
+        unmapped=["*oh*"],
+    )
+
+
+def test_missing_reference_with_markdown_implicit():
+    run_references_test(
+        url_map={"Foo": "foo.html#Foo"},
+        source="[`Foo`][]",
+        output="<p>[<code>Foo</code>][]</p>",
+        unmapped=[],
+    )


### PR DESCRIPTION
Define a "transport representation" for autorefs:

```html
<span data-mkdocstrings-identifier="SomeIdentifier">SomeHTML</span>
```

First a native Markdown extension translates from the usual `[SomeMarkdown][SomeIdentifier]` to the above, and then the post-process replacement mechanism (which is kept in the same place as before) doesn't need to be so careful and complicated, it just indiscriminately replaces such exact strings.

This is a very big boost in performance and I think is more future-proof.

Other mkdocstrings handlers are also free to use this mechanism: define whatever syntax for autorefs that they need and then insert this exact HTML themselves, for the postprocessing to pick up later. It used to be possible to insert the square-brackets Markdown before, but that was very fragile.

Fixes #187.