### PR TITLE
Don't limit CI runs to just master branch

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,8 +2,6 @@ name: ci
 
 on:
   push:
-    branches:
-      - master
   pull_request:
     branches:
       - master


### PR DESCRIPTION
GitHub actions are limited only to the branch that they are defined on anyway. So all this did was to prevent CI from running on a dev/feature branch