### PR TITLE
fix: More lenient regex for data-mkdocstrings-identifier

### DIFF
--- a/src/mkdocstrings/references.py
+++ b/src/mkdocstrings/references.py
@@ -7,7 +7,7 @@ from xml.etree.ElementTree import Element  # noqa: S405 (input is our own, and M
 
 from markdown.inlinepatterns import REFERENCE_RE, ReferenceInlineProcessor
 
-AUTO_REF_RE = re.compile(r'<span data-mkdocstrings-identifier="(?P<identifier>[^"<>]*)">(?P<title>.*?)</span>')
+AUTO_REF_RE = re.compile(r'<span data-mkdocstrings-identifier=("?)(?P<identifier>[^"<>]*)\1>(?P<title>.*?)</span>')
 """
 A regular expression to match mkdocstrings' special reference markers
 in the [`on_post_page` hook][mkdocstrings.plugin.MkdocstringsPlugin.on_post_page].


### PR DESCRIPTION
First introduced in https://github.com/pawamoy/mkdocstrings/pull/188, there's a regression: if something messes with the final HTML before mkdocstrings plugin gets to it, it can't be detected and replaced.
A known case is with 'minify' plugin if it appears before our plugin in the config (which it shouldn't anyway).
  
So workaround this specific case. Make the attribute quotes optional to also catch minified HTML.
Hard to do much else, though perhaps a warning would make sense.
