### PR TITLE
Make ids of Markdown sub-documents prefixed with the parent item id

### DIFF
--- a/src/mkdocstrings/handlers/base.py
+++ b/src/mkdocstrings/handlers/base.py
@@ -380,7 +380,7 @@ class _IdPrependingTreeprocessor(Treeprocessor):
         super().__init__(md)
         self.id_prefix = id_prefix
 
-    def run(self, root: Element):
+    def run(self, root: Element):  # noqa: WPS231 (not complex)
         if not self.id_prefix:
             return
         for el in root.iter():

--- a/src/mkdocstrings/templates/python/material/attribute.html
+++ b/src/mkdocstrings/templates/python/material/attribute.html
@@ -2,6 +2,7 @@
 {% if config.show_if_no_docstring or attribute.has_contents %}
 
   <div class="doc doc-object doc-attribute">
+  {% with html_id = attribute.path %}
 
     {% if not root or config.show_root_heading %}
 
@@ -16,7 +17,7 @@
       {% endif %}
 
       <h{{ heading_level }}
-          id="{{ attribute.path }}"
+          id="{{ html_id }}"
           class="doc doc-heading"
           data-toc-label="{{ attribute.name }}">
 
@@ -34,8 +35,8 @@
     {% else %}
       {% if config.show_root_toc_entry %}
         <h{{ heading_level }} class="hidden-toc"
-            href="#{{ attribute.path }}"
-            id="{{ attribute.path }}"
+            href="#{{ html_id }}"
+            id="{{ html_id }}"
             data-toc-label="{{ attribute.path }}"
             style="visibility: hidden; position: absolute;">
         </h{{ heading_level }}>
@@ -49,6 +50,7 @@
       {% endwith %}
     </div>
 
+  {% endwith %}
   </div>
 
 {% endif %}

--- a/src/mkdocstrings/templates/python/material/attributes.html
+++ b/src/mkdocstrings/templates/python/material/attributes.html
@@ -13,7 +13,7 @@
       <tr>
         <td><code>{{ attribute.name }}</code></td>
         <td><code>{{ attribute.annotation }}</code></td>
-        <td>{{ attribute.description|convert_markdown(heading_level) }}</td>
+        <td>{{ attribute.description|convert_markdown(heading_level, html_id) }}</td>
       </tr>
     {% endfor %}
   </tbody>

--- a/src/mkdocstrings/templates/python/material/class.html
+++ b/src/mkdocstrings/templates/python/material/class.html
@@ -2,6 +2,7 @@
 {% if config.show_if_no_docstring or class.has_contents %}
 
   <div class="doc doc-object doc-class">
+  {% with html_id = class.path %}
 
     {% if not root or config.show_root_heading %}
 
@@ -16,7 +17,7 @@
       {% endif %}
 
       <h{{ heading_level }}
-          id="{{ class.path }}"
+          id="{{ html_id }}"
           class="doc doc-heading"
           data-toc-label="{{ class.name }}">
 
@@ -31,8 +32,8 @@
     {% else %}
       {% if config.show_root_toc_entry %}
         <h{{ heading_level }} class="hidden-toc"
-            href="#{{ class.path }}"
-            id="{{ class.path }}"
+            href="#{{ html_id }}"
+            id="{{ html_id }}"
             data-toc-label="{{ class.path }}"
             style="visibility: hidden; position: absolute;">
         </h{{ heading_level }}>
@@ -59,6 +60,7 @@
       {% endwith %}
     </div>
 
+  {% endwith %}
   </div>
 
 {% endif %}

--- a/src/mkdocstrings/templates/python/material/docstring.html
+++ b/src/mkdocstrings/templates/python/material/docstring.html
@@ -2,7 +2,7 @@
 {% if docstring_sections %}
   {% for section in docstring_sections %}
     {% if section.type == "markdown" %}
-      {{ section.value|convert_markdown(heading_level) }}
+      {{ section.value|convert_markdown(heading_level, html_id) }}
     {% elif section.type == "attributes" %}
       {% with attributes = section.value %}
         {% include "attributes.html" with context %}

--- a/src/mkdocstrings/templates/python/material/examples.html
+++ b/src/mkdocstrings/templates/python/material/examples.html
@@ -2,7 +2,7 @@
 <p><strong>Examples:</strong></p>
 {% for section_type, sub_section in examples %}
   {% if section_type == "markdown" %}
-    {{ sub_section|convert_markdown(heading_level) }}
+    {{ sub_section|convert_markdown(heading_level, html_id) }}
   {% elif section_type == "examples" %}
     {{ sub_section|highlight(language="python", line_nums=False) }}
   {% endif %}

--- a/src/mkdocstrings/templates/python/material/exceptions.html
+++ b/src/mkdocstrings/templates/python/material/exceptions.html
@@ -11,7 +11,7 @@
     {% for exception in exceptions %}
       <tr>
         <td><code>{{ exception.annotation }}</code></td>
-        <td>{{ exception.description|convert_markdown(heading_level) }}</td>
+        <td>{{ exception.description|convert_markdown(heading_level, html_id) }}</td>
       </tr>
     {% endfor %}
   </tbody>

--- a/src/mkdocstrings/templates/python/material/function.html
+++ b/src/mkdocstrings/templates/python/material/function.html
@@ -2,6 +2,7 @@
 {% if config.show_if_no_docstring or function.has_contents %}
 
   <div class="doc doc-object doc-function">
+  {% with html_id = function.path %}
 
     {% if not root or config.show_root_heading %}
 
@@ -16,7 +17,7 @@
       {% endif %}
 
       <h{{ heading_level }}
-          id="{{ function.path }}"
+          id="{{ html_id }}"
           class="doc doc-heading"
           data-toc-label="{{ function.name }}()">
 
@@ -34,8 +35,8 @@
     {% else %}
       {% if config.show_root_toc_entry %}
         <h{{ heading_level }} class="hidden-toc"
-            href="#{{ function.path }}"
-            id="{{ function.path }}"
+            href="#{{ html_id }}"
+            id="{{ html_id }}"
             data-toc-label="{{ function.path }}"
             style="visibility: hidden; position: absolute;">
         </h{{ heading_level }}>
@@ -56,6 +57,7 @@
       {% endif %}
     </div>
 
+  {% endwith %}
   </div>
 
 {% endif %}

--- a/src/mkdocstrings/templates/python/material/method.html
+++ b/src/mkdocstrings/templates/python/material/method.html
@@ -2,6 +2,7 @@
 {% if config.show_if_no_docstring or method.has_contents %}
 
   <div class="doc doc-object doc-method">
+  {% with html_id = method.path %}
 
     {% if not root or config.show_root_heading %}
 
@@ -16,7 +17,7 @@
       {% endif %}
 
       <h{{ heading_level }}
-          id="{{ method.path }}"
+          id="{{ html_id }}"
           class="doc doc-heading"
           data-toc-label="{{ method.name }}()">
 
@@ -34,8 +35,8 @@
     {% else %}
       {% if config.show_root_toc_entry %}
         <h{{ heading_level }} class="hidden-toc"
-            href="#{{ method.path }}"
-            id="{{ method.path }}"
+            href="#{{ html_id }}"
+            id="{{ html_id }}"
             data-toc-label="{{ method.path }}"
             style="visibility: hidden; position: absolute;">
         </h{{ heading_level }}>
@@ -56,6 +57,7 @@
       {% endif %}
     </div>
 
+  {% endwith %}
   </div>
 
 {% endif %}

--- a/src/mkdocstrings/templates/python/material/module.html
+++ b/src/mkdocstrings/templates/python/material/module.html
@@ -2,6 +2,7 @@
 {% if config.show_if_no_docstring or module.has_contents %}
 
   <div class="doc doc-object doc-module">
+  {% with html_id = module.path %}
 
     {% if not root or config.show_root_heading %}
 
@@ -16,7 +17,7 @@
       {% endif %}
 
       <h{{ heading_level }}
-          id="{{ module.path }}"
+          id="{{ html_id }}"
           class="doc doc-heading"
           data-toc-label="{{ module.name }}">
 
@@ -31,8 +32,8 @@
     {% else %}
       {% if config.show_root_toc_entry %}
         <h{{ heading_level }} class="hidden-toc"
-            href="#{{ module.path }}"
-            id="{{ module.path }}"
+            href="#{{ html_id }}"
+            id="{{ html_id }}"
             data-toc-label="{{ module.path }}"
             style="visibility: hidden; position: absolute;">
         </h{{ heading_level }}>
@@ -52,6 +53,7 @@
       {% endwith %}
     </div>
 
+  {% endwith %}
   </div>
 
 {% endif %}

--- a/src/mkdocstrings/templates/python/material/parameters.html
+++ b/src/mkdocstrings/templates/python/material/parameters.html
@@ -14,7 +14,7 @@
       <tr>
         <td><code>{{ parameter.name }}</code></td>
         <td><code>{{ parameter.annotation }}</code></td>
-        <td>{{ parameter.description|convert_markdown(heading_level) }}</td>
+        <td>{{ parameter.description|convert_markdown(heading_level, html_id) }}</td>
         <td>{% if parameter.default %}<code>{{ parameter.default }}</code>{% else %}<em>required</em>{% endif %}</td>
       </tr>
     {% endfor %}

--- a/src/mkdocstrings/templates/python/material/return.html
+++ b/src/mkdocstrings/templates/python/material/return.html
@@ -10,7 +10,7 @@
   <tbody>
     <tr>
       <td><code>{{ return.annotation }}</code></td>
-      <td>{{ return.description|convert_markdown(heading_level) }}</td>
+      <td>{{ return.description|convert_markdown(heading_level, html_id) }}</td>
     </tr>
   </tbody>
 </table>

--- a/src/mkdocstrings/templates/python/readthedocs/exceptions.html
+++ b/src/mkdocstrings/templates/python/readthedocs/exceptions.html
@@ -10,7 +10,7 @@
       <td class="field-body">
         <ul class="first simple">
           {% for exception in exceptions %}
-            <li>{{ ("`" + exception.annotation + "` – " + exception.description)|convert_markdown(heading_level) }}</li>
+            <li>{{ ("`" + exception.annotation + "` – " + exception.description)|convert_markdown(heading_level, html_id) }}</li>
           {% endfor %}
         </ul>
       </td>

--- a/src/mkdocstrings/templates/python/readthedocs/parameters.html
+++ b/src/mkdocstrings/templates/python/readthedocs/parameters.html
@@ -10,7 +10,7 @@
       <td class="field-body">
         <ul class="first simple">
           {% for parameter in parameters %}
-            <li>{{ ("**" + parameter.name + "** (`" + parameter.annotation + "`) – " + parameter.description)|convert_markdown(heading_level) }}</li>
+            <li>{{ ("**" + parameter.name + "** (`" + parameter.annotation + "`) – " + parameter.description)|convert_markdown(heading_level, html_id) }}</li>
           {% endfor %}
         </ul>
       </td>

--- a/src/mkdocstrings/templates/python/readthedocs/return.html
+++ b/src/mkdocstrings/templates/python/readthedocs/return.html
@@ -9,7 +9,7 @@
     <th class="field-name">Returns:</th>
     <td class="field-body">
         <ul class="first simple">
-          <li>{{ ("`" + return.annotation + "` – " + return.description)|convert_markdown(heading_level) }}</li>
+          <li>{{ ("`" + return.annotation + "` – " + return.description)|convert_markdown(heading_level, html_id) }}</li>
         </ul>
     </td>
     </tr>


### PR DESCRIPTION
Fixes #193
https://github.com/pawamoy/mkdocstrings/issues/193#issuecomment-749134463

Fixes #186 
https://github.com/pawamoy/mkdocstrings/issues/186#issuecomment-743469671
