### PR TITLE
Disable Jinja's auto_reload, to reduce disk reads

### DIFF
--- a/src/mkdocstrings/handlers/base.py
+++ b/src/mkdocstrings/handlers/base.py
@@ -190,7 +190,11 @@ class BaseRenderer(ABC):
         if self.fallback_theme != "":
             paths.append(themes_dir / self.fallback_theme)
 
-        self.env = Environment(autoescape=True, loader=FileSystemLoader(paths))  # type: ignore
+        self.env = Environment(
+            autoescape=True,
+            loader=FileSystemLoader(paths),
+            auto_reload=False,  # Editing a template in the middle of a build is not useful.
+        )  # type: ignore
         self.env.filters["any"] = do_any
         self.env.globals["log"] = get_template_logger()
 


### PR DESCRIPTION
Any time a template is referenced, even though it's cached in memory, Jinja ends up doing a filesystem access, to check whether the template file has been modified and so would need to be recompiled.
But it's not even useful to be able to modify a template file on disk in the middle of a mkdocs build.

[An equivalent change to MkDocs itself proved to improve performance significantly](https://github.com/mkdocs/mkdocs/pull/2261). I can't say the same about mkdocstrings, as its templates aren't as nested, but it'll still help. And just good for consistency now.