### PR TITLE
refactor: Theme-agnostic code highlighting, respecting configs

### DIFF
--- a/src/mkdocstrings/handlers/base.py
+++ b/src/mkdocstrings/handlers/base.py
@@ -65,7 +65,7 @@ class Highlighter(Highlight):
         self._css_class = config.pop("css_class", "highlight")
         super().__init__(**{k: v for k, v in config.items() if k in self._highlight_config_keys})
 
-    def highlight(
+    def highlight(  # noqa: W0221 (intentionally different params, we're extending the functionality)
         self,
         src: str,
         language: str = None,

--- a/src/mkdocstrings/handlers/base.py
+++ b/src/mkdocstrings/handlers/base.py
@@ -21,9 +21,10 @@ from xml.etree.ElementTree import Element  # noqa: S405 (we choose to trust the 
 from jinja2 import Environment, FileSystemLoader
 from markdown import Markdown
 from markdown.extensions import Extension
+from markdown.extensions.codehilite import CodeHiliteExtension
 from markdown.treeprocessors import Treeprocessor
 from markupsafe import Markup
-from pymdownx.highlight import Highlight
+from pymdownx.highlight import Highlight, HighlightExtension
 
 from mkdocstrings.loggers import get_template_logger
 
@@ -39,75 +40,69 @@ class ThemeNotSupported(Exception):
     """An exception raised to tell a theme is not supported."""
 
 
-def do_highlight(
-    src: str,
-    guess_lang: bool = False,
-    language: str = None,
-    inline: bool = False,
-    dedent: bool = True,
-    line_nums: bool = False,
-    line_start: int = 1,
-) -> str:
-    """
-    Highlight a code-snippet.
+class Highlighter(Highlight):
+    """Code highlighter that tries to match the Markdown configuration."""
 
-    This function is used as a filter in Jinja templates.
+    _highlight_config_keys = frozenset(
+        "use_pygments guess_lang css_class pygments_style noclasses linenums language_prefix".split(),
+    )
 
-    Arguments:
-        src: The code to highlight.
-        guess_lang: Whether to guess the language or not.
-        language: Explicitly tell what language to use for highlighting.
-        inline: Whether to do inline highlighting.
-        dedent: Whether to dedent the code before highlighting it or not.
-        line_nums: Whether to add line numbers in the result.
-        line_start: The line number to start with.
+    def __init__(self, md: Markdown):
+        """Configure to match a `markdown.Markdown` instance.
 
-    Returns:
-        The highlighted code as HTML text, marked safe (not escaped for HTML).
-    """
-    if dedent:
-        src = textwrap.dedent(src)
+        Arguments:
+            md: The Markdown instance to read configs from.
+        """
+        config = {}
+        for ext in md.registeredExtensions:
+            if isinstance(ext, HighlightExtension) and (ext.enabled or not config):
+                config = ext.getConfigs()
+                break  # This one takes priority, no need to continue looking
+            if isinstance(ext, CodeHiliteExtension) and not config:
+                config = ext.getConfigs()
+                config["language_prefix"] = config["lang_prefix"]
+        self._css_class = config.pop("css_class", "highlight")
+        super().__init__(**{k: v for k, v in config.items() if k in self._highlight_config_keys})
 
-    highlighter = Highlight(use_pygments=True, guess_lang=guess_lang, linenums=line_nums)
-    result = highlighter.highlight(src=src, language=language, linestart=line_start, inline=inline)
+    def highlight(
+        self,
+        src: str,
+        language: str = None,
+        *,
+        inline: bool = False,
+        dedent: bool = True,
+        linenums: Optional[bool] = None,
+        **kwargs,
+    ) -> str:
+        """
+        Highlight a code-snippet.
 
-    if inline:
-        return Markup(f'<code class="highlight language-{language}">{result.text}</code>')
-    return Markup(result)
+        Arguments:
+            src: The code to highlight.
+            language: Explicitly tell what language to use for highlighting.
+            inline: Whether to highlight as inline.
+            dedent: Whether to dedent the code before highlighting it or not.
+            linenums: Whether to add line numbers in the result.
+            **kwargs: Pass on to `pymdownx.highlight.Highlight.highlight`.
 
+        Returns:
+            The highlighted code as HTML text, marked safe (not escaped for HTML).
+        """
+        if dedent:
+            src = textwrap.dedent(src)
 
-def do_js_highlight(
-    src: str,
-    guess_lang: bool = False,  # noqa: W0613 (we must accept the same parameters as do_highlight)
-    language: str = None,
-    inline: bool = False,
-    dedent: bool = True,
-    line_nums: bool = False,  # noqa: W0613
-    line_start: int = 1,  # noqa: W0613
-) -> str:
-    """
-    Prepare a code-snippet for JS highlighting.
+        kwargs.setdefault("css_class", self._css_class)
+        old_linenums = self.linenums
+        if linenums is not None:
+            self.linenums = linenums
+        try:
+            result = super().highlight(src, language, inline=inline, **kwargs)
+        finally:
+            self.linenums = old_linenums
 
-    This function is used as a filter in Jinja templates.
-
-    Arguments:
-        src: The code to highlight.
-        guess_lang: Whether to guess the language or not.
-        language: Explicitly tell what language to use for highlighting.
-        inline: Whether to do inline highlighting.
-        dedent: Whether to dedent the code before highlighting it or not.
-        line_nums: Whether to add line numbers in the result.
-        line_start: The line number to start with.
-
-    Returns:
-        The code properly wrapped for later highlighting by JavaScript.
-    """
-    if dedent:
-        src = textwrap.dedent(src)
-    if inline:
-        src = re.sub(r"\n\s*", "", src)
-        return Markup(f'<code class="highlight">{src}</code>')
-    return Markup(f'<div class="highlight {language or ""}"><pre><code>\n{src}\n</code></pre></div>')
+        if inline:
+            return Markup(f'<code class="highlight language-{language}">{result.text}</code>')
+        return Markup(result)
 
 
 def do_any(seq: Sequence, attribute: str = None) -> bool:
@@ -198,13 +193,6 @@ class BaseRenderer(ABC):
         self.env.filters["any"] = do_any
         self.env.globals["log"] = get_template_logger()
 
-        if theme == "readthedocs":
-            highlight_function = do_js_highlight
-        else:
-            highlight_function = do_highlight
-
-        self.env.filters["highlight"] = highlight_function
-
     @abstractmethod
     def render(self, data: Any, config: dict) -> str:
         """
@@ -227,6 +215,8 @@ class BaseRenderer(ABC):
             config: Configuration options for `mkdocs` and `mkdocstrings`, read from `mkdocs.yml`. See the source code
                 of [mkdocstrings.plugin.MkdocstringsPlugin.on_config][] to see what's in this dictionary.
         """
+        self.env.filters["highlight"] = Highlighter(md).highlight
+
         extensions = config["mdx"] + [ShiftHeadingsExtension(), PrefixIdsExtension()]
         configs = dict(config["mdx_configs"])
         # Prevent a bug that happens due to treeprocessors running on the same fragment both as the inner doc and as

--- a/src/mkdocstrings/templates/python/material/attribute.html
+++ b/src/mkdocstrings/templates/python/material/attribute.html
@@ -23,7 +23,7 @@
 
         <code class="highlight">
           {% if show_full_path %}{{ attribute.path }}{% else %}{{ attribute.name }}{% endif %}
-          {% if attribute.type %}: {{ attribute.type|highlight(language="python", inline=True)|safe }}{% endif %}
+          {% if attribute.type %}: {{ attribute.type|highlight(language="python", inline=True) }}{% endif %}
         </code>
 
         {% with properties = attribute.properties %}

--- a/src/mkdocstrings/templates/python/material/class.html
+++ b/src/mkdocstrings/templates/python/material/class.html
@@ -48,7 +48,7 @@
       {% if config.show_source and class.source %}
         <details class="quote">
           <summary>Source code in <code>{{ class.relative_file_path }}</code></summary>
-          {{ class.source.code|highlight(language="python", line_start=class.source.line_start) }}
+          {{ class.source.code|highlight(language="python", linestart=class.source.line_start, linenums=False) }}
         </details>
       {% endif %}
 

--- a/src/mkdocstrings/templates/python/material/examples.html
+++ b/src/mkdocstrings/templates/python/material/examples.html
@@ -4,6 +4,6 @@
   {% if section_type == "markdown" %}
     {{ sub_section|convert_markdown(heading_level, html_id) }}
   {% elif section_type == "examples" %}
-    {{ sub_section|highlight(language="python", line_nums=False) }}
+    {{ sub_section|highlight(language="python", linenums=False) }}
   {% endif %}
 {% endfor %}

--- a/src/mkdocstrings/templates/python/material/function.html
+++ b/src/mkdocstrings/templates/python/material/function.html
@@ -51,7 +51,7 @@
       {% if config.show_source and function.source %}
         <details class="quote">
           <summary>Source code in <code>{{ function.relative_file_path }}</code></summary>
-          {{ function.source.code|highlight(language="python", line_start=function.source.line_start) }}
+          {{ function.source.code|highlight(language="python", linestart=function.source.line_start, linenums=False) }}
         </details>
       {% endif %}
     </div>

--- a/src/mkdocstrings/templates/python/material/method.html
+++ b/src/mkdocstrings/templates/python/material/method.html
@@ -51,7 +51,7 @@
       {% if config.show_source and method.source %}
         <details class="quote">
           <summary>Source code in <code>{{ method.relative_file_path }}</code></summary>
-          {{ method.source.code|highlight(language="python", line_start=method.source.line_start) }}
+          {{ method.source.code|highlight(language="python", linestart=method.source.line_start, linenums=False) }}
         </details>
       {% endif %}
     </div>

--- a/src/mkdocstrings/templates/python/material/signature.html
+++ b/src/mkdocstrings/templates/python/material/signature.html
@@ -1,31 +1,31 @@
 {{ log.debug() }}
-{% if signature %}
-  {% with %}
-    {% set ns = namespace(render_pos_only_separator=True, render_kw_only_separator=True, equal="=") %}
+{%- if signature -%}
+  {%- with -%}
+    {%- set ns = namespace(render_pos_only_separator=True, render_kw_only_separator=True, equal="=") -%}
 
-    {% if config.show_signature_annotations %}
-      {% set ns.equal = " = " %}
-    {% endif %}
+    {%- if config.show_signature_annotations -%}
+      {%- set ns.equal = " = " -%}
+    {%- endif -%}
 
-    ({% for parameter in signature.parameters %}{% if parameter.kind == "POSITIONAL_ONLY" %}
-      {% if ns.render_pos_only_separator %}
-        {% set ns.render_pos_only_separator = False %}/, {% endif %}
-      {% elif parameter.kind == "KEYWORD_ONLY" %}
-        {% if ns.render_kw_only_separator %}
-          {% set ns.render_kw_only_separator = False %}*, {% endif %}
-      {% endif %}
-      {% if config.show_signature_annotations and "annotation" in parameter %}
-        {% set annotation = ": " + parameter.annotation|safe %}
-      {% endif %}
-      {% if "default" in parameter %}
-        {% set default = ns.equal + parameter.default|safe %}
-      {% endif %}
-      {% if parameter.kind == "VAR_POSITIONAL" %}*
-        {% set render_kw_only_separator = False %}
-      {% elif parameter.kind == "VAR_KEYWORD" %}**
-      {% endif %}{{ parameter.name }}{{ annotation }}{{ default }}{% if not loop.last %}, {% endif %}
-    {% endfor %}){% if config.show_signature_annotations and "return_annotation" in signature %} -> {{ signature.return_annotation }}
-    {% endif %}
+    ({%- for parameter in signature.parameters %}{% if parameter.kind == "POSITIONAL_ONLY" -%}
+      {%- if ns.render_pos_only_separator -%}
+        {%- set ns.render_pos_only_separator = False %}/, {% endif -%}
+      {%- elif parameter.kind == "KEYWORD_ONLY" -%}
+        {%- if ns.render_kw_only_separator -%}
+          {%- set ns.render_kw_only_separator = False %}*, {% endif -%}
+      {%- endif -%}
+      {%- if config.show_signature_annotations and "annotation" in parameter -%}
+        {%- set annotation = ": " + parameter.annotation|safe -%}
+      {%- endif -%}
+      {%- if "default" in parameter -%}
+        {%- set default = ns.equal + parameter.default|safe -%}
+      {%- endif -%}
+      {%- if parameter.kind == "VAR_POSITIONAL" %}*
+        {%- set render_kw_only_separator = False -%}
+      {%- elif parameter.kind == "VAR_KEYWORD" %}**
+      {%- endif %}{{ parameter.name }}{{ annotation }}{{ default }}{% if not loop.last %}, {% endif -%}
+    {%- endfor %}){% if config.show_signature_annotations and "return_annotation" in signature %} -> {{ signature.return_annotation }}
+    {%- endif -%}
 
-  {% endwith %}
-{% endif %}
+  {%- endwith -%}
+{%- endif -%}

--- a/tests/test_handlers.py
+++ b/tests/test_handlers.py
@@ -1,0 +1,35 @@
+"""Tests for the handlers.base module."""
+
+import pytest
+from markdown import Markdown
+
+from mkdocstrings.handlers.base import Highlighter
+
+
+@pytest.mark.parametrize("extension_name", ["codehilite", "pymdownx.highlight"])
+def test_highlighter_without_pygments(extension_name):
+    configs = {extension_name: {"use_pygments": False, "css_class": "hiiii"}}
+    md = Markdown(extensions=configs, extension_configs=configs)
+    hl = Highlighter(md)
+    assert (
+        hl.highlight("import foo", language="python")
+        == '<pre class="hiiii"><code class="language-python">import foo</code></pre>'
+    )
+    assert (
+        hl.highlight("import foo", language="python", inline=True)
+        == '<code class="highlight language-python">import foo</code>'
+    )
+
+
+@pytest.mark.parametrize("extension_name", [None, "codehilite", "pymdownx.highlight"])
+@pytest.mark.parametrize("inline", [False, True])
+def test_highlighter_basic(extension_name, inline):
+    configs = {}
+    if extension_name:
+        configs[extension_name] = {}
+    md = Markdown(extensions=configs, extension_configs=configs)
+    hl = Highlighter(md)
+
+    actual = hl.highlight("import foo", language="python", inline=inline)
+    assert "import" in actual
+    assert "import foo" not in actual

--- a/tests/test_handlers.py
+++ b/tests/test_handlers.py
@@ -8,6 +8,12 @@ from mkdocstrings.handlers.base import Highlighter
 
 @pytest.mark.parametrize("extension_name", ["codehilite", "pymdownx.highlight"])
 def test_highlighter_without_pygments(extension_name):
+    """
+    Assert that it's possible to disable Pygments highlighting.
+
+    Arguments:
+        extension_name: The "user-chosen" Markdown extension for syntax highlighting.
+    """
     configs = {extension_name: {"use_pygments": False, "css_class": "hiiii"}}
     md = Markdown(extensions=configs, extension_configs=configs)
     hl = Highlighter(md)
@@ -24,6 +30,13 @@ def test_highlighter_without_pygments(extension_name):
 @pytest.mark.parametrize("extension_name", [None, "codehilite", "pymdownx.highlight"])
 @pytest.mark.parametrize("inline", [False, True])
 def test_highlighter_basic(extension_name, inline):
+    """
+    Assert that Pygments syntax highlighting works.
+
+    Arguments:
+        extension_name: The "user-chosen" Markdown extension for syntax highlighting.
+        inline: Whether the highlighting was inline.
+    """
     configs = {}
     if extension_name:
         configs[extension_name] = {}
@@ -32,4 +45,4 @@ def test_highlighter_basic(extension_name, inline):
 
     actual = hl.highlight("import foo", language="python", inline=inline)
     assert "import" in actual
-    assert "import foo" not in actual
+    assert "import foo" not in actual  # Highlighting has split it up.


### PR DESCRIPTION
Infer the highlighter configs from what the current Markdown config is, trying to mimick the two most typical extensions and how they'd highlight a code block in Markdown normally.

This improves theme support, as previously only some assumptions based on each theme's defaults were supported, e.g. the readthedocs theme is assumed to rely only on JS highlighting, when in reality you just need to add a Markdown syntax highlight extension and you can use Pygments.

I had commented on this here: https://github.com/pawamoy/mkdocstrings/pull/159#discussion_r502792729

Another improvement stemming from this is support for disabling syntax highlighting altogether. (`use_pygments: false`). For that I also had to edit the template for function signature, to avoid all newlines in it, because previously inline highlighting relied on processing of the syntax highlighter to get rid of those.

Note that, according to the basic logic of this change (inferring highlight config from Markdown config), if there is no highlight extension selected, this one should disable highlighting as well. But I decided to enable highlighting by defauly, unless `use_pygments: False` is specified, because even mkdocstrings repo itself doesn't explicitly specify a highlighter, and would "regress".

And personal note: I don't really need this to make it into the upcoming release, would prefer it to not block the release.