### PR TITLE
fix: Don't wrongly discard text immediately before an autodoc

### DIFF
--- a/src/mkdocstrings/extension.py
+++ b/src/mkdocstrings/extension.py
@@ -148,6 +148,8 @@ class AutoDocProcessor(BlockProcessor):
         match = self.regex.search(str(block))
 
         if match:
+            if match.start() > 0:
+                self.parser.parseBlocks(parent, [block[: match.start()]])
             # removes the first line
             block = block[match.end() :]  # type: ignore
 

--- a/tests/test_extension.py
+++ b/tests/test_extension.py
@@ -61,6 +61,18 @@ def test_markdown_heading_level():
     assert "<h6>Baz</h6>" in output
 
 
+def test_keeps_preceding_text():
+    """Assert that autodoc is recognized in the middle of a block and preceding text is kept."""
+    config = dict(_DEFAULT_CONFIG)
+    config["mdx"] = [MkdocstringsExtension(config, Handlers(config))]
+    md = Markdown(extensions=config["mdx"])
+
+    output = md.convert("**preceding**\n::: tests.fixtures.headings")
+    assert "<strong>preceding</strong>" in output
+    assert "<h2>Foo</h2>" in output
+    assert ":::" not in output
+
+
 def test_reference_inside_autodoc():
     """Assert cross-reference Markdown extension works correctly."""
     config = dict(_DEFAULT_CONFIG)


### PR DESCRIPTION
```markdown
foo
**foo**
::: some.identifier
```

In the previous state, the "foo" text would be completely obliterated, but now it will be kept, and the autodoc will be rendered as well.
