### PR TITLE
tests: Run teardown for Handlers, refactor into contextmanager

### DIFF
--- a/tests/test_extension.py
+++ b/tests/test_extension.py
@@ -1,4 +1,5 @@
 """Tests for the extension module."""
+from contextlib import contextmanager
 from textwrap import dedent
 
 from markdown import Markdown
@@ -6,44 +7,47 @@ from markdown import Markdown
 from mkdocstrings.extension import MkdocstringsExtension
 from mkdocstrings.handlers.base import Handlers
 
-_DEFAULT_CONFIG = {  # noqa: WPS407 (mutable constant)
-    "theme_name": "material",
-    "mdx": [],
-    "mdx_configs": {},
-    "mkdocstrings": {"default_handler": "python", "custom_templates": None, "watch": [], "handlers": {}},
-}
+
+@contextmanager
+def ext_markdown(**kwargs):
+    """Yield a Markdown instance with MkdocstringsExtension, with config adjustments from **kwargs."""
+    config = {
+        "theme_name": "material",
+        "mdx": [],
+        "mdx_configs": {},
+        "mkdocstrings": {"default_handler": "python", "custom_templates": None, "watch": [], "handlers": {}},
+    }
+    config.update(kwargs)
+    handlers = Handlers(config)
+    config["mdx"].append(MkdocstringsExtension(config, handlers))
+    yield Markdown(extensions=config["mdx"], extension_configs=config["mdx_configs"])
+    handlers.teardown()
 
 
 def test_render_html_escaped_sequences():
     """Assert HTML-escaped sequences are correctly parsed as XML."""
-    config = dict(_DEFAULT_CONFIG)
-    config["mdx"] = [MkdocstringsExtension(config, Handlers(config))]
-    md = Markdown(extensions=config["mdx"])
-
-    md.convert("::: tests.fixtures.html_escaped_sequences")
+    with ext_markdown() as md:
+        md.convert("::: tests.fixtures.html_escaped_sequences")
 
 
 def test_multiple_footnotes():
     """Assert footnotes don't get added to subsequent docstrings."""
-    config = dict(_DEFAULT_CONFIG, mdx=["footnotes"])
-    config["mdx"] = [MkdocstringsExtension(config, Handlers(config))]
-    md = Markdown(extensions=config["mdx"])
+    with ext_markdown(mdx=["footnotes"]) as md:
+        output = md.convert(
+            dedent(
+                """
+                Top.[^aaa]
 
-    output = md.convert(
-        dedent(
-            """
-            Top.[^aaa]
+                ::: tests.fixtures.footnotes.func_a
 
-            ::: tests.fixtures.footnotes.func_a
+                ::: tests.fixtures.footnotes.func_b
 
-            ::: tests.fixtures.footnotes.func_b
+                ::: tests.fixtures.footnotes.func_c
 
-            ::: tests.fixtures.footnotes.func_c
-
-            [^aaa]: Top footnote
-            """,
-        ),
-    )
+                [^aaa]: Top footnote
+                """,
+            ),
+        )
     assert output.count("Footnote A") == 1
     assert output.count("Footnote B") == 1
     assert output.count("Top footnote") == 1
@@ -51,11 +55,8 @@ def test_multiple_footnotes():
 
 def test_markdown_heading_level():
     """Assert that Markdown headings' level doesn't exceed heading_level."""
-    config = dict(_DEFAULT_CONFIG)
-    config["mdx"] = [MkdocstringsExtension(config, Handlers(config))]
-    md = Markdown(extensions=config["mdx"])
-
-    output = md.convert("::: tests.fixtures.headings\n    rendering:\n      show_root_heading: true")
+    with ext_markdown() as md:
+        output = md.convert("::: tests.fixtures.headings\n    rendering:\n      show_root_heading: true")
     assert "<h3>Foo</h3>" in output
     assert "<h5>Bar</h5>" in output
     assert "<h6>Baz</h6>" in output
@@ -63,11 +64,8 @@ def test_markdown_heading_level():
 
 def test_keeps_preceding_text():
     """Assert that autodoc is recognized in the middle of a block and preceding text is kept."""
-    config = dict(_DEFAULT_CONFIG)
-    config["mdx"] = [MkdocstringsExtension(config, Handlers(config))]
-    md = Markdown(extensions=config["mdx"])
-
-    output = md.convert("**preceding**\n::: tests.fixtures.headings")
+    with ext_markdown() as md:
+        output = md.convert("**preceding**\n::: tests.fixtures.headings")
     assert "<strong>preceding</strong>" in output
     assert "<h2>Foo</h2>" in output
     assert ":::" not in output
@@ -75,21 +73,14 @@ def test_keeps_preceding_text():
 
 def test_reference_inside_autodoc():
     """Assert cross-reference Markdown extension works correctly."""
-    config = dict(_DEFAULT_CONFIG)
-    config["mdx"] = [MkdocstringsExtension(config, Handlers(config))]
-    md = Markdown(extensions=config["mdx"])
-
-    output = md.convert("::: tests.fixtures.cross_reference")
+    with ext_markdown() as md:
+        output = md.convert("::: tests.fixtures.cross_reference")
     snippet = 'Link to <span data-mkdocstrings-identifier="something.Else">something.Else</span>.'
     assert snippet in output
 
 
 def test_no_double_toc():
     """Asserts that the 'toc' extension doesn't apply its modification twice."""
-    config = dict(_DEFAULT_CONFIG)
-    config["mdx_configs"] = {"toc": {"permalink": "@@@"}}
-    config["mdx"] = ["toc", MkdocstringsExtension(config, Handlers(config))]
-    md = Markdown(extensions=config["mdx"], extension_configs=config["mdx_configs"])
-
-    output = md.convert("::: tests.fixtures.headings")
+    with ext_markdown(mdx=["toc"], mdx_configs={"toc": {"permalink": "@@@"}}) as md:
+        output = md.convert("::: tests.fixtures.headings")
     assert 3 <= output.count("@@@") < 6

--- a/tests/test_extension.py
+++ b/tests/test_extension.py
@@ -10,7 +10,14 @@ from mkdocstrings.handlers.base import Handlers
 
 @contextmanager
 def ext_markdown(**kwargs):
-    """Yield a Markdown instance with MkdocstringsExtension, with config adjustments from **kwargs."""
+    """Yield a Markdown instance with MkdocstringsExtension, with config adjustments from **kwargs.
+
+    Arguments:
+        **kwargs: Changes to apply to the config, on top of the default config.
+
+    Yields:
+        A `markdown.Markdown` instance.
+    """
     config = {
         "theme_name": "material",
         "mdx": [],


### PR DESCRIPTION
This fixes random test failures that for some reason showed up only on Windows Python 3.6
