### PR TITLE
refactor: Don't re-parse the whole subdoc, expose only headings

### DIFF
--- a/docs/css/mkdocstrings.css
+++ b/docs/css/mkdocstrings.css
@@ -10,17 +10,6 @@ h5.doc-heading {
   text-transform: none !important;
 }
 
-/* Don't use vertical space on hidden ToC entries. */
-.hidden-toc::before {
-  margin-top: 0 !important;
-  padding-top: 0 !important;
-}
-
-/* Don't show permalink of hidden ToC entries. */
-.hidden-toc a.headerlink {
-  display: none;
-}
-
 /* Avoid breaking parameters name, etc. in table cells. */
 td code {
   word-break: normal !important;

--- a/docs/handlers/python.md
+++ b/docs/handlers/python.md
@@ -335,17 +335,6 @@ h5.doc-heading {
   text-transform: none !important;
 }
 
-/* Don't use vertical space on hidden ToC entries. */
-.hidden-toc::before {
-  margin-top: 0 !important;
-  padding-top: 0 !important;
-}
-
-/* Don't show permalink of hidden ToC entries. */
-.hidden-toc a.headerlink {
-  display: none;
-}
-
 /* Avoid breaking parameters name, etc. in table cells. */
 td code {
   word-break: normal !important;
@@ -368,17 +357,6 @@ div.doc-contents:not(.first) {
   padding-left: 25px;
   border-left: 4px solid rgba(230, 230, 230);
   margin-bottom: 60px;
-}
-
-/* Don't use vertical space on hidden ToC entries. */
-.hidden-toc::before {
-  margin-top: 0 !important;
-  padding-top: 0 !important;
-}
-
-/* Don't show permalink of hidden ToC entries. */
-.hidden-toc a.headerlink {
-  display: none;
 }
 
 /* Avoid breaking parameters name, etc. in table cells. */

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -93,6 +93,7 @@ exclude = ["tests/fixtures"]
     "-F821",  # redundant with E0602 (undefined variable)
     "-Q000",  # black already deals with quoting
     "-S101",  # use of assert
+    "-S405",  # we are not parsing XML
     "-W503",  # line break before binary operator (incompatible with Black)
     "-C0103", # two-lowercase-letters variable DO conform to snake_case naming style
     "-C0116",  # redunant with D102 (missing docstring)

--- a/src/mkdocstrings/extension.py
+++ b/src/mkdocstrings/extension.py
@@ -197,7 +197,7 @@ class AutoDocProcessor(BlockProcessor):
 
         if not self._updated_env:
             log.debug("Updating renderer's env")
-            handler.renderer.update_env(self.md, self._config)
+            handler.renderer._update_env(self._config)
             self._updated_env = True
 
         log.debug("Rendering templates")

--- a/src/mkdocstrings/extension.py
+++ b/src/mkdocstrings/extension.py
@@ -277,9 +277,6 @@ class MkdocstringsExtension(Extension):
     It cannot work outside of `mkdocstrings`.
     """
 
-    blockprocessor_priority = 75  # Right before markdown.blockprocessors.HashHeaderProcessor
-    inlineprocessor_priority = 168  # Right after markdown.inlinepatterns.ReferenceInlineProcessor
-
     def __init__(self, config: dict, handlers: Handlers, **kwargs) -> None:
         """
         Initialize the object.
@@ -303,8 +300,13 @@ class MkdocstringsExtension(Extension):
         Arguments:
             md: A `markdown.Markdown` instance.
         """
-        md.registerExtension(self)
-        processor = AutoDocProcessor(md.parser, md, self._config, self._handlers)
-        md.parser.blockprocessors.register(processor, "mkdocstrings", self.blockprocessor_priority)
-        ref_processor = AutoRefInlineProcessor(md)
-        md.inlinePatterns.register(ref_processor, "mkdocstrings", self.inlineprocessor_priority)
+        md.parser.blockprocessors.register(
+            AutoDocProcessor(md.parser, md, self._config, self._handlers),
+            "mkdocstrings",
+            priority=75,  # Right before markdown.blockprocessors.HashHeaderProcessor
+        )
+        md.inlinePatterns.register(
+            AutoRefInlineProcessor(md),
+            "mkdocstrings",
+            priority=168,  # Right after markdown.inlinepatterns.ReferenceInlineProcessor
+        )

--- a/src/mkdocstrings/handlers/base.py
+++ b/src/mkdocstrings/handlers/base.py
@@ -218,7 +218,7 @@ class BaseRenderer(ABC):
             The rendered template as HTML.
         """  # noqa: DAR202 (excess return section)
 
-    def update_env(self, md: Markdown, config: dict) -> None:
+    def update_env(self, md: Markdown, config: dict) -> None:  # noqa: W0613 (unused argument 'config')
         """
         Update the Jinja environment.
 
@@ -227,6 +227,9 @@ class BaseRenderer(ABC):
             config: Configuration options for `mkdocs` and `mkdocstrings`, read from `mkdocs.yml`. See the source code
                 of [mkdocstrings.plugin.MkdocstringsPlugin.on_config][] to see what's in this dictionary.
         """
+        self.env.filters["convert_markdown"] = functools.partial(do_convert_markdown, md)
+
+    def _update_env(self, config: dict):
         extensions = config["mdx"] + [_MkdocstringsInnerExtension()]
         configs = dict(config["mdx_configs"])
         # Prevent a bug that happens due to treeprocessors running on the same fragment both as the inner doc and as
@@ -238,8 +241,7 @@ class BaseRenderer(ABC):
             pass
 
         md = Markdown(extensions=extensions, extension_configs=configs)
-
-        self.env.filters["convert_markdown"] = functools.partial(do_convert_markdown, md)
+        self.update_env(md, config)
 
 
 class BaseCollector(ABC):

--- a/src/mkdocstrings/handlers/base.py
+++ b/src/mkdocstrings/handlers/base.py
@@ -225,6 +225,7 @@ class BaseRenderer(ABC):
         content: str,
         heading_level: int,
         *,
+        hidden: bool = False,
         toc_label: Optional[str] = None,
         **attributes: str,
     ) -> Markup:
@@ -234,6 +235,7 @@ class BaseRenderer(ABC):
         Arguments:
             content: The HTML within the heading.
             heading_level: The level of heading (e.g. 3 -> `h3`).
+            hidden: If True, only register it for the table of contents, don't render anything.
             toc_label: The title to use in the table of contents ('data-toc-label' attribute).
             attributes: Any extra HTML attributes of the heading.
 
@@ -246,6 +248,9 @@ class BaseRenderer(ABC):
             toc_label = content.unescape() if isinstance(el, Markup) else content
         el.set("data-toc-label", toc_label)
         self._headings.append(el)
+
+        if hidden:
+            return Markup('<a id="{0}"></a>').format(attributes["id"])
 
         # Now produce the actual HTML to be rendered. The goal is to wrap the HTML content into a heading.
         # Start with a heading that has just attributes (no text), and add a placeholder into it.

--- a/src/mkdocstrings/references.py
+++ b/src/mkdocstrings/references.py
@@ -3,7 +3,7 @@
 import re
 from html import escape, unescape
 from typing import Any, Callable, Dict, List, Match, Tuple, Union
-from xml.etree.ElementTree import Element  # noqa: S405 (input is our own, and Markdown coming from code)
+from xml.etree.ElementTree import Element
 
 from markdown.inlinepatterns import REFERENCE_RE, ReferenceInlineProcessor
 

--- a/src/mkdocstrings/templates/python/material/attribute.html
+++ b/src/mkdocstrings/templates/python/material/attribute.html
@@ -16,10 +16,10 @@
         {% set show_full_path = config.show_object_full_path %}
       {% endif %}
 
-      <h{{ heading_level }}
-          id="{{ html_id }}"
-          class="doc doc-heading"
-          data-toc-label="{{ attribute.name }}">
+      {% filter heading(heading_level,
+          id=html_id,
+          class="doc doc-heading",
+          toc_label=attribute.name) %}
 
         {% filter highlight(language="python", inline=True) %}
           {% if show_full_path %}{{ attribute.path }}{% else %}{{ attribute.name }}{% endif %}
@@ -30,15 +30,16 @@
           {% include "properties.html" with context %}
         {% endwith %}
 
-      </h{{ heading_level }}>
+      {% endfilter %}
 
     {% else %}
       {% if config.show_root_toc_entry %}
-        <h{{ heading_level }} class="hidden-toc"
-            id="{{ html_id }}"
-            data-toc-label="{{ attribute.path }}"
-            style="visibility: hidden; position: absolute;">
-        </h{{ heading_level }}>
+        {% filter heading(heading_level,
+            class="hidden-toc",
+            id=html_id,
+            toc_label=attribute.path,
+            style="visibility: hidden; position: absolute;") %}
+        {% endfilter %}
       {% endif %}
       {% set heading_level = heading_level - 1 %}
     {% endif %}

--- a/src/mkdocstrings/templates/python/material/attribute.html
+++ b/src/mkdocstrings/templates/python/material/attribute.html
@@ -35,10 +35,9 @@
     {% else %}
       {% if config.show_root_toc_entry %}
         {% filter heading(heading_level,
-            class="hidden-toc",
             id=html_id,
             toc_label=attribute.path,
-            style="visibility: hidden; position: absolute;") %}
+            hidden=True) %}
         {% endfilter %}
       {% endif %}
       {% set heading_level = heading_level - 1 %}

--- a/src/mkdocstrings/templates/python/material/children.html
+++ b/src/mkdocstrings/templates/python/material/children.html
@@ -14,7 +14,7 @@
         {% endif %}
 
         {% if config.show_category_heading and obj.attributes|any("has_contents") %}
-          <h{{ heading_level }}>Attributes</h{{ heading_level }}>
+          {% filter heading(heading_level, id=html_id ~ "-attributes") %}Attributes{% endfilter %}
         {% endif %}
         {% with heading_level = heading_level + extra_level %}
           {% for attribute in obj.attributes|sort(attribute="name") %}
@@ -23,7 +23,7 @@
         {% endwith %}
 
         {% if config.show_category_heading and obj.classes|any("has_contents") %}
-          <h{{ heading_level }}>Classes</h{{ heading_level }}>
+          {% filter heading(heading_level, id=html_id ~ "-classes") %}Classes{% endfilter %}
         {% endif %}
         {% with heading_level = heading_level + extra_level %}
           {% for class in obj.classes|sort(attribute="name") %}
@@ -32,7 +32,7 @@
         {% endwith %}
 
         {% if config.show_category_heading and obj.functions|any("has_contents") %}
-          <h{{ heading_level }}>Functions</h{{ heading_level }}>
+          {% filter heading(heading_level, id=html_id ~ "-functions") %}Functions{% endfilter %}
         {% endif %}
         {% with heading_level = heading_level + extra_level %}
           {% for function in obj.functions|sort(attribute="name") %}
@@ -41,7 +41,7 @@
         {% endwith %}
 
         {% if config.show_category_heading and obj.methods|any("has_contents") %}
-          <h{{ heading_level }}>Methods</h{{ heading_level }}>
+          {% filter heading(heading_level, id=html_id ~ "-methods") %}Methods{% endfilter %}
         {% endif %}
         {% with heading_level = heading_level + extra_level %}
           {% for method in obj.methods|sort(attribute="name") %}
@@ -50,7 +50,7 @@
         {% endwith %}
 
         {% if config.show_category_heading and obj.modules|any("has_contents") %}
-          <h{{ heading_level }}>Modules</h{{ heading_level }}>
+          {% filter heading(heading_level, id=html_id ~ "-modules") %}Modules{% endfilter %}
         {% endif %}
         {% with heading_level = heading_level + extra_level %}
           {% for module in obj.modules|sort(attribute="name") %}

--- a/src/mkdocstrings/templates/python/material/class.html
+++ b/src/mkdocstrings/templates/python/material/class.html
@@ -32,10 +32,9 @@
     {% else %}
       {% if config.show_root_toc_entry %}
         {% filter heading(heading_level,
-            class="hidden-toc",
             id=html_id,
             toc_label=class.path,
-            style="visibility: hidden; position: absolute;") %}
+            hidden=True) %}
         {% endfilter %}
       {% endif %}
       {% set heading_level = heading_level - 1 %}

--- a/src/mkdocstrings/templates/python/material/class.html
+++ b/src/mkdocstrings/templates/python/material/class.html
@@ -16,10 +16,10 @@
         {% set show_full_path = config.show_object_full_path %}
       {% endif %}
 
-      <h{{ heading_level }}
-          id="{{ html_id }}"
-          class="doc doc-heading"
-          data-toc-label="{{ class.name }}">
+      {% filter heading(heading_level,
+          id=html_id,
+          class="doc doc-heading",
+          toc_label=class.name) %}
 
         <code>{% if show_full_path %}{{ class.path }}{% else %}{{ class.name }}{% endif %}</code>
 
@@ -27,15 +27,16 @@
           {% include "properties.html" with context %}
         {% endwith %}
 
-      </h{{ heading_level }}>
+      {% endfilter %}
 
     {% else %}
       {% if config.show_root_toc_entry %}
-        <h{{ heading_level }} class="hidden-toc"
-            id="{{ html_id }}"
-            data-toc-label="{{ class.path }}"
-            style="visibility: hidden; position: absolute;">
-        </h{{ heading_level }}>
+        {% filter heading(heading_level,
+            class="hidden-toc",
+            id=html_id,
+            toc_label=class.path,
+            style="visibility: hidden; position: absolute;") %}
+        {% endfilter %}
       {% endif %}
       {% set heading_level = heading_level - 1 %}
     {% endif %}

--- a/src/mkdocstrings/templates/python/material/function.html
+++ b/src/mkdocstrings/templates/python/material/function.html
@@ -35,10 +35,9 @@
     {% else %}
       {% if config.show_root_toc_entry %}
         {% filter heading(heading_level,
-            class="hidden-toc",
             id=html_id,
             toc_label=function.path,
-            style="visibility: hidden; position: absolute;") %}
+            hidden=True) %}
         {% endfilter %}
       {% endif %}
       {% set heading_level = heading_level - 1 %}

--- a/src/mkdocstrings/templates/python/material/function.html
+++ b/src/mkdocstrings/templates/python/material/function.html
@@ -16,10 +16,10 @@
         {% set show_full_path = config.show_object_full_path %}
       {% endif %}
 
-      <h{{ heading_level }}
-          id="{{ html_id }}"
-          class="doc doc-heading"
-          data-toc-label="{{ function.name }}()">
+      {% filter heading(heading_level,
+          id=html_id,
+          class="doc doc-heading",
+          toc_label=function.name ~ "()") %}
 
         {% filter highlight(language="python", inline=True) %}
           {% if show_full_path %}{{ function.path }}{% else %}{{ function.name }}{% endif %}
@@ -30,15 +30,16 @@
           {% include "properties.html" with context %}
         {% endwith %}
 
-      </h{{ heading_level }}>
+      {% endfilter %}
 
     {% else %}
       {% if config.show_root_toc_entry %}
-        <h{{ heading_level }} class="hidden-toc"
-            id="{{ html_id }}"
-            data-toc-label="{{ function.path }}"
-            style="visibility: hidden; position: absolute;">
-        </h{{ heading_level }}>
+        {% filter heading(heading_level,
+            class="hidden-toc",
+            id=html_id,
+            toc_label=function.path,
+            style="visibility: hidden; position: absolute;") %}
+        {% endfilter %}
       {% endif %}
       {% set heading_level = heading_level - 1 %}
     {% endif %}

--- a/src/mkdocstrings/templates/python/material/method.html
+++ b/src/mkdocstrings/templates/python/material/method.html
@@ -35,10 +35,9 @@
     {% else %}
       {% if config.show_root_toc_entry %}
         {% filter heading(heading_level,
-            class="hidden-toc",
             id=html_id,
             toc_label=method.path,
-            style="visibility: hidden; position: absolute;") %}
+            hidden=True) %}
         {% endfilter %}
       {% endif %}
       {% set heading_level = heading_level - 1 %}

--- a/src/mkdocstrings/templates/python/material/method.html
+++ b/src/mkdocstrings/templates/python/material/method.html
@@ -16,10 +16,10 @@
         {% set show_full_path = config.show_object_full_path %}
       {% endif %}
 
-      <h{{ heading_level }}
-          id="{{ html_id }}"
-          class="doc doc-heading"
-          data-toc-label="{{ method.name }}()">
+      {% filter heading(heading_level,
+          id=html_id,
+          class="doc doc-heading",
+          toc_label=method.name ~ "()") %}
 
         {% filter highlight(language="python", inline=True) %}
           {% if show_full_path %}{{ method.path }}{% else %}{{ method.name }}{% endif %}
@@ -30,15 +30,16 @@
           {% include "properties.html" with context %}
         {% endwith %}
 
-      </h{{ heading_level }}>
+      {% endfilter %}
 
     {% else %}
       {% if config.show_root_toc_entry %}
-        <h{{ heading_level }} class="hidden-toc"
-            id="{{ html_id }}"
-            data-toc-label="{{ method.path }}"
-            style="visibility: hidden; position: absolute;">
-        </h{{ heading_level }}>
+        {% filter heading(heading_level,
+            class="hidden-toc",
+            id=html_id,
+            toc_label=method.path,
+            style="visibility: hidden; position: absolute;") %}
+        {% endfilter %}
       {% endif %}
       {% set heading_level = heading_level - 1 %}
     {% endif %}

--- a/src/mkdocstrings/templates/python/material/module.html
+++ b/src/mkdocstrings/templates/python/material/module.html
@@ -32,10 +32,9 @@
     {% else %}
       {% if config.show_root_toc_entry %}
         {% filter heading(heading_level,
-            class="hidden-toc",
             id=html_id,
             toc_label=module.path,
-            style="visibility: hidden; position: absolute;") %}
+            hidden=True) %}
         {% endfilter %}
       {% endif %}
       {% set heading_level = heading_level - 1 %}

--- a/src/mkdocstrings/templates/python/material/module.html
+++ b/src/mkdocstrings/templates/python/material/module.html
@@ -16,10 +16,10 @@
         {% set show_full_path = config.show_object_full_path %}
       {% endif %}
 
-      <h{{ heading_level }}
-          id="{{ html_id }}"
-          class="doc doc-heading"
-          data-toc-label="{{ module.name }}">
+      {% filter heading(heading_level,
+          id=html_id,
+          class="doc doc-heading",
+          toc_label=module.name) %}
 
         <code>{% if show_full_path %}{{ module.path }}{% else %}{{ module.name }}{% endif %}</code>
 
@@ -27,15 +27,16 @@
           {% include "properties.html" with context %}
         {% endwith %}
 
-      </h{{ heading_level }}>
+      {% endfilter %}
 
     {% else %}
       {% if config.show_root_toc_entry %}
-        <h{{ heading_level }} class="hidden-toc"
-            id="{{ html_id }}"
-            data-toc-label="{{ module.path }}"
-            style="visibility: hidden; position: absolute;">
-        </h{{ heading_level }}>
+        {% filter heading(heading_level,
+            class="hidden-toc",
+            id=html_id,
+            toc_label=module.path,
+            style="visibility: hidden; position: absolute;") %}
+        {% endfilter %}
       {% endif %}
       {% set heading_level = heading_level - 1 %}
     {% endif %}

--- a/tests/fixtures/builtin.py
+++ b/tests/fixtures/builtin.py
@@ -1,0 +1,2 @@
+def func(foo=print):
+    """test"""

--- a/tests/test_extension.py
+++ b/tests/test_extension.py
@@ -27,6 +27,7 @@ def ext_markdown(**kwargs):
         "mkdocstrings": {"default_handler": "python", "custom_templates": None, "watch": [], "handlers": {}},
     }
     config.update(kwargs)
+    config["mdx"].append("toc")  # Guaranteed to be added by MkDocs.
     original_config = copy.deepcopy(config)
 
     handlers = Handlers(config)
@@ -73,9 +74,9 @@ def test_markdown_heading_level():
     """Assert that Markdown headings' level doesn't exceed heading_level."""
     with ext_markdown() as md:
         output = md.convert("::: tests.fixtures.headings\n    rendering:\n      show_root_heading: true")
-    assert "<h3>Foo</h3>" in output
-    assert "<h5>Bar</h5>" in output
-    assert "<h6>Baz</h6>" in output
+    assert ">Foo</h3>" in output
+    assert ">Bar</h5>" in output
+    assert ">Baz</h6>" in output
 
 
 def test_keeps_preceding_text():
@@ -83,7 +84,7 @@ def test_keeps_preceding_text():
     with ext_markdown() as md:
         output = md.convert("**preceding**\n::: tests.fixtures.headings")
     assert "<strong>preceding</strong>" in output
-    assert "<h2>Foo</h2>" in output
+    assert ">Foo</h2>" in output
     assert ":::" not in output
 
 
@@ -95,10 +96,19 @@ def test_reference_inside_autodoc():
     assert snippet in output
 
 
+def test_html_inside_heading():
+    """Assert that headings don't double-escape HTML."""
+    with ext_markdown() as md:
+        output = md.convert("::: tests.fixtures.builtin")
+    assert "=&lt;" in output
+    assert "&amp;" not in output
+
+
 @pytest.mark.parametrize(
     ("permalink_setting", "expect_permalink"),
     [
         ("@@@", "@@@"),
+        ("TeSt", "TeSt"),
         (True, "&para;"),
     ],
 )
@@ -110,7 +120,7 @@ def test_no_double_toc(permalink_setting, expect_permalink):
         permalink_setting: The 'permalink' setting of 'toc' extension.
         expect_permalink: Text of the permalink to search for in the output.
     """
-    with ext_markdown(mdx=["toc"], mdx_configs={"toc": {"permalink": permalink_setting}}) as md:
+    with ext_markdown(mdx_configs={"toc": {"permalink": permalink_setting}}) as md:
         output = md.convert(
             dedent(
                 """
@@ -125,3 +135,29 @@ def test_no_double_toc(permalink_setting, expect_permalink):
             )
         )
     assert output.count(expect_permalink) == 5
+    assert 'id="tests.fixtures.headings--foo"' in output
+    assert md.toc_tokens == [  # noqa: E1101 (the member gets populated only with 'toc' extension)
+        {
+            "level": 1,
+            "id": "aa",
+            "name": "aa",
+            "children": [
+                {
+                    "level": 2,
+                    "id": "tests.fixtures.headings--foo",
+                    "name": "Foo",
+                    "children": [
+                        {
+                            "level": 4,
+                            "id": "tests.fixtures.headings--bar",
+                            "name": "Bar",
+                            "children": [
+                                {"level": 6, "id": "tests.fixtures.headings--baz", "name": "Baz", "children": []}
+                            ],
+                        }
+                    ],
+                }
+            ],
+        },
+        {"level": 1, "id": "bb", "name": "bb", "children": []},
+    ]


### PR DESCRIPTION

* ## refactor: Merge md extensions into one, to reduce boilerplate


* ## refactor: Pass the actual used Markdown instance to update_env
    
    The fact that we're re-instantiating Markdown used to be seen as a hack, but now it's required and preferred.


* ## refactor: Move do_convert_markdown method into the class

* ## refactor: Don't re-parse the whole subdoc, expose only headings
    
    Previously the autodoc sub-document (HTML with nested Markdown) was being re-integrated into the top-level document by the way of parsing it as XML and inserting it back into the XML tree of the top-level markdown duri>
    This gave a lot of side effects that need to be worked around. XML parsing, Markdown double-processing (with only situational workaround possible), etc.
    
    Now, the document will be inserted as fully opaque HTML, so those issues are avoided entirely. But now there are new issues to overcome!
    
    * The ToC extension can no longer see through this subdocument, so no ToC entries can be generated. I thought a lot how to re-add these properly, and there's no easy solution without parsing the HTML. In the end I deci>
    
    * MkDocs can no longer fix relative paths in this subdocument. That one is much easier: just manually re-add its treeprocessor.

* ## refactor: Actually exclude hidden headings from the doc
    
    Now we separately control which headings appear in the doc and which in the ToC. No need to hide them with CSS now.